### PR TITLE
chore: small cleanups (utf-8 stdout, datetime utc, federation logging)

### DIFF
--- a/omni_add.py
+++ b/omni_add.py
@@ -10,7 +10,11 @@ from omni_version import add_version_argument
 
 def add_memory(text, source="user_input", tags=None, prefer_service=False):
     doc_id = str(uuid.uuid4())
-    timestamp = datetime.datetime.utcnow().isoformat(timespec="microseconds")
+    timestamp = (
+        datetime.datetime.now(datetime.timezone.utc)
+        .replace(tzinfo=None)
+        .isoformat(timespec="microseconds")
+    )
     metadata = build_base_metadata(
         source=source,
         timestamp=timestamp,

--- a/omni_metadata.py
+++ b/omni_metadata.py
@@ -2,7 +2,11 @@ import datetime
 
 
 def current_timestamp():
-    return datetime.datetime.utcnow().isoformat(timespec="microseconds")
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .replace(tzinfo=None)
+        .isoformat(timespec="microseconds")
+    )
 
 
 def _normalize_datetime(parsed_datetime):

--- a/omni_ops.py
+++ b/omni_ops.py
@@ -24,7 +24,7 @@ def _is_missing_collection_error(exc):
 
 
 def _utc_timestamp():
-    return datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
 
 def _ensure_output_path(output_path, default_dir, prefix, suffix, overwrite):
@@ -52,7 +52,7 @@ def _write_tar_json(tar_handle, arcname, payload):
     body = json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8")
     info = tarfile.TarInfo(name=arcname)
     info.size = len(body)
-    info.mtime = int(datetime.datetime.utcnow().timestamp())
+    info.mtime = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
     tar_handle.addfile(info, io.BytesIO(body))
 
 
@@ -83,7 +83,10 @@ def create_backup(
     manifest = {
         "tool": "omni_backup",
         "version": get_version(),
-        "created_at": datetime.datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "created_at": datetime.datetime.now(datetime.timezone.utc)
+        .replace(tzinfo=None)
+        .isoformat(timespec="seconds")
+        + "Z",
         "install_mode": runtime_config["install_mode"],
         "runtime_home": str(runtime_home),
         "db_dir": str(db_dir),
@@ -148,7 +151,10 @@ def export_memories(output_path=None, overwrite=False, root_dir=SOURCE_ROOT):
     export_payload = {
         "tool": "omni_export",
         "version": get_version(),
-        "exported_at": datetime.datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "exported_at": datetime.datetime.now(datetime.timezone.utc)
+        .replace(tzinfo=None)
+        .isoformat(timespec="seconds")
+        + "Z",
         "collection_name": COLLECTION_NAME,
         "record_count": len(items),
         "items": items,

--- a/omni_reindex.py
+++ b/omni_reindex.py
@@ -22,7 +22,7 @@ def _is_missing_collection_error(exc):
 
 
 def _utc_stamp():
-    return datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
 
 def _normalize_source_filter(source):

--- a/omni_search.py
+++ b/omni_search.py
@@ -81,7 +81,8 @@ def federate_with_notes(query, core_records, n_results=5):
         from omni_note_index import search_notes
 
         note_records = search_notes(query, n_results=n_results)
-    except Exception:
+    except Exception as exc:
+        print(f"warn: notes federation skipped: {exc}", file=sys.stderr)
         note_records = []
 
     for record in note_records:
@@ -101,7 +102,8 @@ def federate_with_notes(query, core_records, n_results=5):
 
         codemap_runtime = CodemapRuntime()
         codemap_records = codemap_runtime.query(query, n_results=n_results)
-    except Exception:
+    except Exception as exc:
+        print(f"warn: codemap federation skipped: {exc}", file=sys.stderr)
         codemap_records = []
 
     for record in codemap_records:

--- a/omnimem.py
+++ b/omnimem.py
@@ -1103,7 +1103,18 @@ def build_parser():
     return parser
 
 
+def _force_utf8_streams():
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if callable(reconfigure):
+            try:
+                reconfigure(encoding="utf-8")
+            except (ValueError, OSError):
+                pass
+
+
 def main(argv=None):
+    _force_utf8_streams()
     parser = build_parser()
     args = parser.parse_args(argv)
 


### PR DESCRIPTION
## Summary
- Reconfigure stdout/stderr to UTF-8 in `main()` — fixes `UnicodeEncodeError` on Windows cp1252 when `note search`/`note show` outputs Vietnamese (or any non-ASCII) content.
- Replace deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)` across `omni_metadata`, `omni_add`, `omni_ops`, `omni_reindex`. Output strings byte-for-byte identical.
- `omni_search.federate_with_notes`: log stderr when notes/codemap federation falls back to empty results. Previously swallowed silently; misconfiguration was undebuggable.

## Test plan
- [x] `python -m unittest discover -s tests` — 209 tests, same baseline as `main` (5 pre-existing failures + 3 errors on Windows env, all unrelated; zero regressions from this PR).
- [x] Smoke: `omnimem.bat note search "tiếng việt" --full --json` runs cleanly with no `PYTHONIOENCODING` set on Windows (previously crashed).
- [x] Smoke: `omnimem.bat doctor`, `version`, `note new/rm/list/search` — all green.
- [x] Datetime format preserved: `current_timestamp()`, `_utc_timestamp()`, `_utc_stamp()` produce identical strings to pre-change output.

## Out of scope
Pre-existing Windows test failures (8.3 short path normalization, codemap test isolation, reindex worker errors) — to be addressed in a follow-up.