### PR TITLE
test: make Windows test suite hermetic

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,8 +16,9 @@ class TestOmniConfig(unittest.TestCase):
 
     def test_repo_local_config_is_loaded_for_git_clone(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            root = Path(temp_dir) / "repo"
+            root = (Path(temp_dir) / "repo")
             root.mkdir()
+            root = root.resolve()
             (root / ".git").mkdir()
             config_path = root / "omnimem.json"
             config_path.write_text(
@@ -86,14 +87,15 @@ class TestOmniConfig(unittest.TestCase):
 
     def test_package_install_prefers_user_config_path(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            site_root = Path(temp_dir) / "site-packages"
+            temp_root = Path(temp_dir).resolve()
+            site_root = temp_root / "site-packages"
             package_root = site_root / "omnimem"
-            config_root = Path(temp_dir) / "config-home"
+            config_root = temp_root / "config-home"
             config_file = config_root / "config.json"
             package_root.mkdir(parents=True)
             config_root.mkdir(parents=True)
             config_file.write_text(
-                json.dumps({"home": str(Path(temp_dir) / "runtime-home")}),
+                json.dumps({"home": str(temp_root / "runtime-home")}),
                 encoding="utf-8",
             )
 
@@ -103,7 +105,7 @@ class TestOmniConfig(unittest.TestCase):
 
             self.assertEqual(preferred, config_file)
             self.assertEqual(report["config"]["selected_path"], str(config_file))
-            self.assertEqual(report["values"]["home"], Path(temp_dir) / "runtime-home")
+            self.assertEqual(report["values"]["home"], temp_root / "runtime-home")
 
     def test_serialize_runtime_config_converts_paths_to_strings(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -97,6 +97,8 @@ class TestOmniOps(unittest.TestCase):
             restore_root = Path(temp_dir) / "restore"
             source_root.mkdir()
             restore_root.mkdir()
+            source_root = source_root.resolve()
+            restore_root = restore_root.resolve()
             (source_root / ".git").mkdir()
             (restore_root / ".git").mkdir()
             source_db = str(source_root / ".omnimem_db")

--- a/tests/test_reindex.py
+++ b/tests/test_reindex.py
@@ -79,6 +79,7 @@ class TestOmniReindex(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir) / "repo"
             root.mkdir()
+            root = root.resolve()
             (root / ".git").mkdir()
             db_path = str(root / ".omnimem_db")
             FakePersistentClient.stores[db_path] = {
@@ -145,6 +146,7 @@ class TestOmniReindex(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir) / "repo"
             root.mkdir()
+            root = root.resolve()
             (root / ".git").mkdir()
             db_path = str(root / ".omnimem_db")
             collection = FakeCollection(
@@ -179,6 +181,7 @@ class TestOmniReindex(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir) / "repo"
             root.mkdir()
+            root = root.resolve()
             (root / ".git").mkdir()
             db_path = str(root / ".omnimem_db")
             collection = FakeCollection(

--- a/tests/test_search_all.py
+++ b/tests/test_search_all.py
@@ -19,6 +19,14 @@ def _remove_tree(path):
     shutil.rmtree(path, ignore_errors=True)
 
 
+class _EmptyCodemapRuntime:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def query(self, query, n_results=5):
+        return []
+
+
 class TestFederateWithNotes(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
@@ -74,7 +82,9 @@ class TestFederateWithNotes(unittest.TestCase):
             {"id": "n2", "distance": 0.5, "document": "c", "metadata": {"id": "n2"}},
         ]
 
-        with patch("omni_note_index.search_notes", return_value=notes):
+        with patch("omni_note_index.search_notes", return_value=notes), patch(
+            "omni_codemap.CodemapRuntime", _EmptyCodemapRuntime
+        ):
             merged = federate_with_notes("query", core, n_results=5)
 
         distances = [record["distance"] for record in merged]
@@ -87,21 +97,27 @@ class TestFederateWithNotes(unittest.TestCase):
             for i in range(5)
         ]
 
-        with patch("omni_note_index.search_notes", return_value=notes):
+        with patch("omni_note_index.search_notes", return_value=notes), patch(
+            "omni_codemap.CodemapRuntime", _EmptyCodemapRuntime
+        ):
             merged = federate_with_notes("query", core, n_results=3)
 
         self.assertEqual(len(merged), 3)
 
     def test_empty_notes_returns_just_core(self):
         core = [{"id": "c1", "distance": 0.2, "content": "a", "metadata": {}}]
-        with patch("omni_note_index.search_notes", return_value=[]):
+        with patch("omni_note_index.search_notes", return_value=[]), patch(
+            "omni_codemap.CodemapRuntime", _EmptyCodemapRuntime
+        ):
             merged = federate_with_notes("query", core, n_results=5)
         self.assertEqual(len(merged), 1)
         self.assertEqual(merged[0]["collection"], "omnimem_core")
 
     def test_search_notes_failure_does_not_break_federation(self):
         core = [{"id": "c1", "distance": 0.2, "content": "a", "metadata": {}}]
-        with patch("omni_note_index.search_notes", side_effect=RuntimeError("boom")):
+        with patch("omni_note_index.search_notes", side_effect=RuntimeError("boom")), patch(
+            "omni_codemap.CodemapRuntime", _EmptyCodemapRuntime
+        ):
             merged = federate_with_notes("query", core, n_results=5)
         self.assertEqual(len(merged), 1)
         self.assertEqual(merged[0]["collection"], "omnimem_core")

--- a/tests/test_write_service.py
+++ b/tests/test_write_service.py
@@ -142,6 +142,7 @@ class TestWriteService(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir) / "repo"
             root.mkdir()
+            root = root.resolve()
             (root / ".git").mkdir()
             db_path = str(root / ".omnimem_db")
             FakePersistentClient.stores = {


### PR DESCRIPTION
## Summary
Fix 6 pre-existing test failures on Windows local runs (Linux CI has always passed). Both root causes are test-only — production code is correct.

### Root cause 1 — tempfile 8.3 short-name vs resolved long-name
On Windows, `os.environ['TEMP']` often contains the 8.3 short form (`C:\Users\MANHLI~1\...`). Production resolves paths via `Path.expanduser().resolve()` which canonicalizes to the long form. Tests using the unresolved tmp path as dict keys for `FakePersistentClient.stores` (or comparing strings against config selected_path) key-mismatched on Windows.

**Fix:** call `.resolve()` on the test root after `mkdir()` so test-side paths match what production computes.
- `tests/test_config.py` (2 tests)
- `tests/test_reindex.py` (3 tests — including one that was passing for the wrong reason; now exercises the real verification path)
- `tests/test_write_service.py` (1 test)
- `tests/test_ops.py` (1 test)

### Root cause 2 — missing CodemapRuntime stub
`tests/test_search_all.py` mocked `omni_note_index.search_notes` but not `omni_codemap.CodemapRuntime`, so `federate_with_notes` hit the real codemap collection. Fine on a fresh CI box, but a dev machine that has built a codemap returns real hits and the assertions break.

**Fix:** add `_EmptyCodemapRuntime` stub and patch consistently in every federation test.

## Test plan
- [x] `python -m unittest discover -s tests` on Windows: **209 passed, 1 skipped, 0 failed** (was 209 with 5 failures + 3 errors).
- [x] Linux CI should remain green (the resolves are no-ops on Linux where tmp paths are already canonical).