### PR TITLE
perf(mcp): cache OmniRuntime / NoteRuntime across tools/call

### DIFF
--- a/omni_mcp.py
+++ b/omni_mcp.py
@@ -12,6 +12,7 @@ Transport: newline-delimited JSON-RPC 2.0 over stdin/stdout.
 
 import json
 import sys
+import threading
 import traceback
 
 from omni_paths import SOURCE_ROOT
@@ -20,6 +21,54 @@ from omni_version import get_version
 JSONRPC_VERSION = "2.0"
 PROTOCOL_VERSION = "2024-11-05"
 SERVER_NAME = "omnimem"
+
+# Runtimes hold a long-lived ChromaDB PersistentClient and a SentenceTransformer
+# embedding function. Reusing them across `tools/call` requests avoids paying
+# the model-load cost (~1-2 s per call) on every MCP invocation. The MCP server
+# is a single-process stdio loop, so caching for the lifetime of the process is
+# safe; key by root_dir so a server reused across vaults stays correct.
+_RUNTIME_CACHE_LOCK = threading.Lock()
+_OMNI_RUNTIME_CACHE = {}
+_NOTE_RUNTIME_CACHE = {}
+
+
+def _get_omni_runtime(root_dir):
+    key = str(root_dir)
+    cached = _OMNI_RUNTIME_CACHE.get(key)
+    if cached is not None:
+        return cached
+    with _RUNTIME_CACHE_LOCK:
+        cached = _OMNI_RUNTIME_CACHE.get(key)
+        if cached is not None:
+            return cached
+        from omni_search_core import OmniRuntime
+
+        runtime = OmniRuntime(root_dir=root_dir)
+        _OMNI_RUNTIME_CACHE[key] = runtime
+        return runtime
+
+
+def _get_note_runtime(root_dir):
+    key = str(root_dir)
+    cached = _NOTE_RUNTIME_CACHE.get(key)
+    if cached is not None:
+        return cached
+    with _RUNTIME_CACHE_LOCK:
+        cached = _NOTE_RUNTIME_CACHE.get(key)
+        if cached is not None:
+            return cached
+        from omni_note_index import NoteRuntime
+
+        runtime = NoteRuntime(root_dir=root_dir)
+        _NOTE_RUNTIME_CACHE[key] = runtime
+        return runtime
+
+
+def _reset_runtime_cache():
+    """Drop cached runtimes — for tests and for reload-after-config-change."""
+    with _RUNTIME_CACHE_LOCK:
+        _OMNI_RUNTIME_CACHE.clear()
+        _NOTE_RUNTIME_CACHE.clear()
 
 
 def _ok(request_id, result):
@@ -170,10 +219,15 @@ def _tool_note_new(args, root_dir):
         root_dir=root_dir,
     )
 
+    try:
+        note_runtime = _get_note_runtime(root_dir)
+    except Exception:
+        note_runtime = None
     index_note_record(
         record["frontmatter"],
         args.get("body") or "",
         record["path"],
+        runtime=note_runtime,
         root_dir=root_dir,
     )
 
@@ -194,12 +248,17 @@ def _tool_note_search(args, root_dir):
     query = args.get("query")
     if not query:
         raise ValueError("note_search requires 'query'")
+    try:
+        note_runtime = _get_note_runtime(root_dir)
+    except Exception:
+        note_runtime = None
     results = search_notes(
         query,
         n_results=int(args.get("limit") or 5),
         note_type=args.get("type"),
         tag=args.get("tag"),
         root_dir=root_dir,
+        runtime=note_runtime,
     )
     payload = []
     for record in results:
@@ -246,9 +305,8 @@ def _tool_note_show(args, root_dir):
 
 
 def _tool_note_link(args, root_dir):
-    from omni_note import add_link
-    from omni_note_index import index_note_record, NoteRuntime
-    from omni_note import read_note
+    from omni_note import add_link, read_note
+    from omni_note_index import index_note_record
 
     from_slug = args.get("from")
     to_slug = args.get("to")
@@ -257,7 +315,7 @@ def _tool_note_link(args, root_dir):
     add_link(from_slug, to_slug, root_dir=root_dir)
     refreshed = read_note(from_slug, root_dir=root_dir)
     try:
-        runtime = NoteRuntime(root_dir=root_dir)
+        runtime = _get_note_runtime(root_dir)
         index_note_record(
             refreshed.get("frontmatter") or {},
             refreshed.get("body") or "",
@@ -272,7 +330,6 @@ def _tool_note_link(args, root_dir):
 
 def _tool_search_all(args, root_dir):
     from omni_note_index import search_notes
-    from omni_search_core import OmniRuntime
 
     query = args.get("query")
     if not query:
@@ -283,7 +340,16 @@ def _tool_search_all(args, root_dir):
     federated = []
 
     try:
-        notes_results = search_notes(query, n_results=limit, root_dir=root_dir)
+        note_runtime = _get_note_runtime(root_dir)
+    except Exception:
+        note_runtime = None
+    try:
+        notes_results = search_notes(
+            query,
+            n_results=limit,
+            root_dir=root_dir,
+            runtime=note_runtime,
+        )
     except Exception:
         notes_results = []
     for record in notes_results:
@@ -301,7 +367,7 @@ def _tool_search_all(args, root_dir):
         )
 
     try:
-        core = OmniRuntime(root_dir=root_dir)
+        core = _get_omni_runtime(root_dir)
         core_results = core.search_records(
             query,
             n_results=limit,
@@ -338,7 +404,9 @@ def _tool_import_file(args, root_dir):
     path = args.get("path")
     if not path:
         raise ValueError("import_file requires 'path'")
-    asyncio.run(import_file_advanced(path, prefer_service=False))
+    # Prefer the warm search service for ingest so we don't reload the
+    # embedding model inside the MCP process when a service is already up.
+    asyncio.run(import_file_advanced(path, prefer_service=True))
     return {"content": _content_text({"imported": True, "path": path})}
 
 

--- a/omni_note_index.py
+++ b/omni_note_index.py
@@ -228,9 +228,10 @@ def search_notes(
     since=None,
     until=None,
     root_dir=SOURCE_ROOT,
+    runtime=None,
 ):
-    runtime = NoteRuntime(root_dir=root_dir)
-    return runtime.search(
+    local_runtime = runtime or NoteRuntime(root_dir=root_dir)
+    return local_runtime.search(
         query,
         n_results=n_results,
         note_type=note_type,

--- a/tests/test_mcp_runtime_cache.py
+++ b/tests/test_mcp_runtime_cache.py
@@ -1,0 +1,90 @@
+"""Verify the MCP server reuses long-lived OmniRuntime / NoteRuntime instances.
+
+Each runtime construction loads ChromaDB and a SentenceTransformer embedding
+function. Without caching, every `tools/call` would pay that cost (~1-2 s on
+first call, smaller but non-zero subsequently). These tests pin the cache
+behavior so a regression would be caught.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import omni_mcp
+
+
+class _CountingOmniRuntime:
+    instances = 0
+
+    def __init__(self, root_dir=None):
+        type(self).instances += 1
+        self.root_dir = root_dir
+
+    def search_records(self, *args, **kwargs):
+        return []
+
+
+class _CountingNoteRuntime:
+    instances = 0
+
+    def __init__(self, root_dir=None):
+        type(self).instances += 1
+        self.root_dir = root_dir
+
+    def search(self, *args, **kwargs):
+        return []
+
+
+class TestRuntimeCache(unittest.TestCase):
+    def setUp(self):
+        omni_mcp._reset_runtime_cache()
+        _CountingOmniRuntime.instances = 0
+        _CountingNoteRuntime.instances = 0
+
+    def tearDown(self):
+        omni_mcp._reset_runtime_cache()
+
+    def test_get_omni_runtime_returns_same_instance_for_same_root(self):
+        with patch("omni_search_core.OmniRuntime", _CountingOmniRuntime):
+            first = omni_mcp._get_omni_runtime("/tmp/vault-a")
+            second = omni_mcp._get_omni_runtime("/tmp/vault-a")
+        self.assertIs(first, second)
+        self.assertEqual(_CountingOmniRuntime.instances, 1)
+
+    def test_get_omni_runtime_separates_by_root_dir(self):
+        with patch("omni_search_core.OmniRuntime", _CountingOmniRuntime):
+            first = omni_mcp._get_omni_runtime("/tmp/vault-a")
+            second = omni_mcp._get_omni_runtime("/tmp/vault-b")
+        self.assertIsNot(first, second)
+        self.assertEqual(_CountingOmniRuntime.instances, 2)
+
+    def test_get_note_runtime_returns_same_instance_for_same_root(self):
+        with patch("omni_note_index.NoteRuntime", _CountingNoteRuntime):
+            first = omni_mcp._get_note_runtime("/tmp/vault-a")
+            second = omni_mcp._get_note_runtime("/tmp/vault-a")
+        self.assertIs(first, second)
+        self.assertEqual(_CountingNoteRuntime.instances, 1)
+
+    def test_get_note_runtime_separates_by_root_dir(self):
+        with patch("omni_note_index.NoteRuntime", _CountingNoteRuntime):
+            first = omni_mcp._get_note_runtime("/tmp/vault-a")
+            second = omni_mcp._get_note_runtime("/tmp/vault-b")
+        self.assertIsNot(first, second)
+        self.assertEqual(_CountingNoteRuntime.instances, 2)
+
+    def test_search_all_tool_reuses_runtimes_across_calls(self):
+        """Two consecutive `search_all` calls must construct each runtime once."""
+        with patch("omni_search_core.OmniRuntime", _CountingOmniRuntime), patch(
+            "omni_note_index.NoteRuntime", _CountingNoteRuntime
+        ):
+            omni_mcp.dispatch_tool(
+                "search_all", {"query": "hello"}, root_dir="/tmp/vault-x"
+            )
+            omni_mcp.dispatch_tool(
+                "search_all", {"query": "world"}, root_dir="/tmp/vault-x"
+            )
+        self.assertEqual(_CountingOmniRuntime.instances, 1)
+        self.assertEqual(_CountingNoteRuntime.instances, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Each `tools/call` request used to construct a fresh `OmniRuntime` or `NoteRuntime`, paying the ChromaDB `PersistentClient` setup and the SentenceTransformer embedding-model load **every time**. The MCP server is a single-process stdio loop — reusing runtimes for the lifetime of the process is safe and was the whole point of running it long-lived.

### Changes
- `omni_mcp.py`: add `_get_omni_runtime` / `_get_note_runtime` helpers backed by per-`root_dir` caches under a shared lock. Replace per-call construction in `_tool_note_link`, `_tool_search_all`, `_tool_note_new`, `_tool_note_search`. `_reset_runtime_cache()` exposed for tests.
- `omni_mcp._tool_import_file`: pass `prefer_service=True` so the warm service is reused when up, instead of bypassing it.
- `omni_note_index.search_notes`: accept an optional `runtime=` parameter so cached callers (currently MCP) don't trigger another `NoteRuntime` construction inside the function.
- `tests/test_mcp_runtime_cache.py` (**new**, 5 tests): pin same-instance reuse, per-`root_dir` separation, and end-to-end runtime reuse across two consecutive `search_all` dispatches.

## Effect
A Claude Desktop / Copilot session that calls `note_search` / `search_all` / `note_new` repeatedly now keeps the embedding model resident across the whole session, saving ~1-2 s reload per request and removing the tqdm progress bar from stderr after the first call.

Verified locally with real ChromaDB runtimes:
```
1st search_all OK: True   (cache size = 1 / 1)
2nd search_all OK: True   (Same omni runtime: True, Same note runtime: True)
```

## Test plan
- [x] `python -m unittest discover -s tests` — 214 passed (was 209), 1 skipped, 0 failed.
- [x] Local smoke against real runtimes: 2 consecutive `search_all` calls reuse both `OmniRuntime` and `NoteRuntime` instances.
- [x] No public API changes — `search_notes(runtime=None)` is backward compatible.