### PR TITLE
fix(hook): gate PostToolUse reindex on vault file path

### DIFF
--- a/omni_hooks.py
+++ b/omni_hooks.py
@@ -11,6 +11,8 @@ import re
 import sys
 from pathlib import Path
 
+from omni_paths import SOURCE_ROOT
+
 OMNIMEM_HOOK_TAG = "omnimem-v1"
 SUPPORTED_AGENTS = ("claude", "codex")
 DEFAULT_EVENTS = ("SessionStart", "Stop", "PostToolUse")
@@ -82,7 +84,7 @@ def _hook_recipe(event):
             "hooks": [
                 {
                     "type": "command",
-                    "command": _format_command(_omnimem_args("note", "reindex")),
+                    "command": _format_command(_omnimem_args("hook", "--gated-reindex")),
                     "tag": OMNIMEM_HOOK_TAG,
                 }
             ],
@@ -218,7 +220,7 @@ def _codex_recipe(events):
     """
     args = " ".join(_quote(part) for part in [_omnimem_command(), *_omnimem_args("note", "list", "--limit", "5", "--json")])
     reindex_args = " ".join(
-        _quote(part) for part in [_omnimem_command(), *_omnimem_args("note", "reindex")]
+        _quote(part) for part in [_omnimem_command(), *_omnimem_args("hook", "--gated-reindex")]
     )
 
     block_lines = [CODEX_BLOCK_START]
@@ -385,3 +387,74 @@ def _normalize_codex_event(event):
         "PostToolUse": "post_tool_use",
     }
     return mapping.get(event, event)
+
+
+def _extract_file_path(payload):
+    """Best-effort: pull a file path out of a hook payload from Claude or Codex."""
+    if not isinstance(payload, dict):
+        return None
+    tool_input = payload.get("tool_input")
+    if isinstance(tool_input, dict):
+        path = tool_input.get("file_path") or tool_input.get("path")
+        if path:
+            return path
+    data = payload.get("data")
+    if isinstance(data, dict):
+        path = data.get("file_path") or data.get("path")
+        if path:
+            return path
+    return payload.get("file_path") or payload.get("path")
+
+
+def _path_is_inside(child, parent):
+    try:
+        Path(child).expanduser().resolve().relative_to(
+            Path(parent).expanduser().resolve()
+        )
+    except (ValueError, OSError):
+        return False
+    return True
+
+
+def gated_reindex_from_stdin(stdin=None, root_dir=SOURCE_ROOT):
+    """Read a PostToolUse payload from stdin and reindex only when a vault
+    file was touched.
+
+    Without this gate, every Edit/Write/MultiEdit on any file in the agent's
+    working directory triggers a full notes reindex — which loads the
+    embedding model and rebuilds the whole `omnimem_notes` collection. On a
+    coding session that edits dozens of files, the cumulative latency is
+    measured in tens of seconds.
+
+    Returns a status dict so the caller can print/log it. Failures (no
+    payload, bad json, no file path, file outside the vault) are NOT errors
+    — they just mean "skip reindex".
+    """
+    stream = stdin if stdin is not None else sys.stdin
+    try:
+        raw = stream.read() if hasattr(stream, "read") else ""
+    except Exception as exc:
+        return {"acted": False, "reason": f"stdin error: {exc}"}
+
+    if not (raw or "").strip():
+        return {"acted": False, "reason": "empty stdin"}
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return {"acted": False, "reason": f"invalid json: {exc}"}
+
+    file_path = _extract_file_path(payload)
+    if not file_path:
+        return {"acted": False, "reason": "no file_path in payload"}
+
+    from omni_vault import get_vault_root
+
+    vault_root = get_vault_root(root_dir=root_dir)
+    if not _path_is_inside(file_path, vault_root):
+        return {"acted": False, "reason": "file outside vault"}
+
+    from omni_note_index import reindex_all_notes
+
+    result = reindex_all_notes(root_dir=root_dir)
+    return {"acted": True, "file_path": str(file_path), "result": result}

--- a/omnimem.py
+++ b/omnimem.py
@@ -575,10 +575,14 @@ def handle_codemap(args):
 
 
 def handle_hook(args):
-    from omni_hooks import HookError, install, status, uninstall
+    from omni_hooks import HookError, gated_reindex_from_stdin, install, status, uninstall
 
     as_json = getattr(args, "json", False)
     try:
+        if getattr(args, "gated_reindex", False):
+            report = gated_reindex_from_stdin()
+            _print(report, as_json)
+            return 0
         if args.status:
             _print(status(), as_json)
             return 0
@@ -1051,6 +1055,15 @@ def build_parser():
     hook_parser.add_argument("--status", action="store_true")
     hook_parser.add_argument("--dry-run", action="store_true")
     hook_parser.add_argument("--json", action="store_true")
+    hook_parser.add_argument(
+        "--gated-reindex",
+        action="store_true",
+        help=(
+            "Internal: read a PostToolUse hook payload from stdin and only "
+            "reindex notes when the touched file lives inside the vault. "
+            "Used by `hook install`'s recipe."
+        ),
+    )
     hook_parser.set_defaults(handler=handle_hook)
 
     quickstart_parser = subparsers.add_parser(

--- a/tests/test_hook_gated_reindex.py
+++ b/tests/test_hook_gated_reindex.py
@@ -1,0 +1,134 @@
+"""Verify the PostToolUse hook only triggers reindex for vault file edits.
+
+Without gating, every Edit/Write/MultiEdit on any file in the agent's
+working directory rebuilt the full notes index. That's expensive and
+unnecessary when the touched file is the user's source code, not a note.
+"""
+
+import io
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _restore_env(name, previous_value):
+    if previous_value is None:
+        os.environ.pop(name, None)
+    else:
+        os.environ[name] = previous_value
+
+
+def _remove_tree(path):
+    import shutil
+
+    shutil.rmtree(path, ignore_errors=True)
+
+
+class TestGatedReindex(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir_path = Path(self.tmpdir).resolve()
+        self.previous_home = os.environ.get("OMNIMEM_HOME")
+        self.addCleanup(_restore_env, "OMNIMEM_HOME", self.previous_home)
+        self.addCleanup(_remove_tree, self.tmpdir)
+        os.environ["OMNIMEM_HOME"] = str(self.tmpdir_path)
+
+        from omni_vault import ensure_vault_layout, get_vault_root
+
+        ensure_vault_layout(root_dir=self.tmpdir_path)
+        self.vault_root = Path(get_vault_root(root_dir=self.tmpdir_path)).resolve()
+        self.vault_note = self.vault_root / "notes" / "decision-foo.md"
+        self.vault_note.parent.mkdir(parents=True, exist_ok=True)
+        self.vault_note.write_text("---\nslug: decision-foo\n---\nbody\n", encoding="utf-8")
+
+    def _run(self, payload, reindex_called=None):
+        from omni_hooks import gated_reindex_from_stdin
+
+        stdin = io.StringIO(json.dumps(payload) if payload is not None else "")
+        calls = []
+
+        def _fake_reindex(root_dir=None, dry_run=False):
+            calls.append({"root_dir": root_dir, "dry_run": dry_run})
+            return {"indexed": 1, "failed": [], "total": 1}
+
+        with patch("omni_note_index.reindex_all_notes", _fake_reindex):
+            report = gated_reindex_from_stdin(stdin=stdin, root_dir=self.tmpdir_path)
+        if reindex_called is not None:
+            self.assertEqual(len(calls), reindex_called, msg=f"report={report}")
+        return report
+
+    def test_skips_when_stdin_empty(self):
+        report = self._run(None, reindex_called=0)
+        self.assertFalse(report["acted"])
+        self.assertEqual(report["reason"], "empty stdin")
+
+    def test_skips_when_payload_is_invalid_json(self):
+        from omni_hooks import gated_reindex_from_stdin
+
+        with patch("omni_note_index.reindex_all_notes") as reindex:
+            report = gated_reindex_from_stdin(
+                stdin=io.StringIO("not-json"),
+                root_dir=self.tmpdir_path,
+            )
+        self.assertFalse(report["acted"])
+        self.assertTrue(report["reason"].startswith("invalid json"))
+        reindex.assert_not_called()
+
+    def test_skips_when_no_file_path_in_payload(self):
+        report = self._run(
+            {"hook_event_name": "PostToolUse", "tool_input": {"foo": "bar"}},
+            reindex_called=0,
+        )
+        self.assertFalse(report["acted"])
+        self.assertEqual(report["reason"], "no file_path in payload")
+
+    def test_skips_when_file_outside_vault(self):
+        outside = self.tmpdir_path / "src" / "main.py"
+        outside.parent.mkdir(parents=True, exist_ok=True)
+        outside.write_text("print('hi')\n", encoding="utf-8")
+        report = self._run(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_input": {"file_path": str(outside)},
+            },
+            reindex_called=0,
+        )
+        self.assertFalse(report["acted"])
+        self.assertEqual(report["reason"], "file outside vault")
+
+    def test_reindexes_when_vault_note_touched_via_claude_payload(self):
+        report = self._run(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_input": {"file_path": str(self.vault_note)},
+            },
+            reindex_called=1,
+        )
+        self.assertTrue(report["acted"])
+        self.assertEqual(Path(report["file_path"]).resolve(), self.vault_note.resolve())
+
+    def test_reindexes_when_vault_note_touched_via_codex_payload(self):
+        # Codex passes hook events under `data.file_path`.
+        report = self._run(
+            {"event": "post_tool_use", "data": {"file_path": str(self.vault_note)}},
+            reindex_called=1,
+        )
+        self.assertTrue(report["acted"])
+
+    def test_post_tool_use_recipe_uses_gated_command(self):
+        # Pin the wire format so a regression in `_hook_recipe` doesn't
+        # silently revert to the old "always reindex" behavior.
+        from omni_hooks import _hook_recipe
+
+        recipe = _hook_recipe("PostToolUse")
+        command = recipe["hooks"][0]["command"]
+        self.assertIn("hook", command)
+        self.assertIn("--gated-reindex", command)
+        self.assertNotIn("note reindex", command)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why
Every Claude Code Edit / Write / MultiEdit was triggering a full notes reindex. Reindex loads the embedding model and rebuilds the entire `omnimem_notes` ChromaDB collection — on a coding session that edits dozens of source files, the cumulative latency runs into tens of seconds.

## What
PostToolUse hooks now invoke `omnimem hook --gated-reindex`, a stdin-aware wrapper:
- Reads the JSON hook payload from stdin (Claude and Codex both ship the touched file under `tool_input.file_path` or `data.file_path`).
- Resolves the OmniMem vault root via the runtime config.
- Reindexes only when the touched file lives inside the vault. Empty stdin / invalid json / missing path / file outside vault → silent no-op.

Both `_hook_recipe(PostToolUse)` and `_codex_recipe(post_tool_use)` were updated to use the new command. Existing users need to re-run `omnimem hook install --agent claude` (or codex) to pick up the gated recipe.

## Test plan
- [x] `tests/test_hook_gated_reindex.py` — 7 cases (empty stdin, malformed json, missing path, file outside vault, Claude-style payload, Codex-style payload, recipe wire-format pin).
- [x] `python -m unittest discover -s tests` — 221 passed, 1 skipped, 0 failed.