### PR TITLE
fix(cli): render note CLI output as readable text when --json is off

### DIFF
--- a/omnimem.py
+++ b/omnimem.py
@@ -205,8 +205,93 @@ def handle_version(_args):
 def _print(payload, as_json):
     if as_json:
         print(json.dumps(payload, ensure_ascii=False, indent=2))
-    else:
-        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return
+    _render_human(payload)
+
+
+_SUMMARY_KEYS = ("slug", "title", "id", "name", "path", "score", "from", "to")
+
+
+def _format_scalar(value):
+    if isinstance(value, float):
+        return f"{value:.3f}"
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _summary_line(item):
+    if not isinstance(item, dict):
+        return None
+    parts = []
+    for key in _SUMMARY_KEYS:
+        if key not in item:
+            continue
+        value = item[key]
+        if value in (None, ""):
+            continue
+        parts.append(f"{key}={_format_scalar(value)}")
+        if len(parts) >= 4:
+            break
+    return " ".join(parts) if parts else None
+
+
+def _render_human(payload, indent=0):
+    pad = "  " * indent
+    if payload is None:
+        print(f"{pad}(none)")
+        return
+    if isinstance(payload, dict):
+        if not payload:
+            print(f"{pad}(empty)")
+            return
+        for key, value in payload.items():
+            _render_field(key, value, indent)
+        return
+    if isinstance(payload, list):
+        if not payload:
+            print(f"{pad}(empty)")
+            return
+        for index, item in enumerate(payload, 1):
+            _render_item(index, item, indent)
+        return
+    print(f"{pad}{_format_scalar(payload)}")
+
+
+def _render_field(key, value, indent):
+    pad = "  " * indent
+    if isinstance(value, str) and "\n" in value:
+        print(f"{pad}{key}:")
+        for line in value.splitlines():
+            print(f"{pad}  {line}")
+        return
+    if isinstance(value, list):
+        print(f"{pad}{key} ({len(value)}):")
+        for index, item in enumerate(value, 1):
+            _render_item(index, item, indent + 1)
+        return
+    if isinstance(value, dict):
+        summary = _summary_line(value)
+        if summary:
+            print(f"{pad}{key}: {summary}")
+            return
+        print(f"{pad}{key}:")
+        _render_human(value, indent + 1)
+        return
+    print(f"{pad}{key}: {_format_scalar(value)}")
+
+
+def _render_item(index, item, indent):
+    pad = "  " * indent
+    if isinstance(item, dict):
+        summary = _summary_line(item)
+        if summary:
+            print(f"{pad}{index}. {summary}")
+            return
+        print(f"{pad}{index}.")
+        _render_human(item, indent + 1)
+        return
+    print(f"{pad}{index}. {_format_scalar(item)}")
 
 
 def _at_date_eod(at_date):

--- a/tests/test_print_human.py
+++ b/tests/test_print_human.py
@@ -1,0 +1,94 @@
+"""Verify the unified note CLI emits a readable plain-text format when
+`--json` is not set.
+
+Before this fix, both branches of `_print` dumped indented JSON, so the
+`--json` flag was a no-op for every note CLI verb. These tests pin the
+new shape (key=value summaries, nested expansion, list counts) so a
+regression doesn't silently restore the JSON-only output.
+"""
+
+import io
+import unittest
+from contextlib import redirect_stdout
+
+import omnimem
+
+
+def _capture(payload, as_json=False):
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        omnimem._print(payload, as_json)
+    return buffer.getvalue()
+
+
+class TestPrintHuman(unittest.TestCase):
+    def test_json_path_still_emits_indented_json(self):
+        out = _capture({"created": {"slug": "foo"}}, as_json=True)
+        self.assertIn('"created"', out)
+        self.assertIn('"slug": "foo"', out)
+
+    def test_dict_with_scalar_value_renders_as_key_value(self):
+        out = _capture({"deleted": "decision-foo"}, as_json=False)
+        self.assertEqual(out.strip(), "deleted: decision-foo")
+
+    def test_dict_with_summary_keys_collapses_to_inline(self):
+        out = _capture(
+            {"created": {"slug": "foo", "title": "Foo Title", "path": "/tmp/foo.md"}},
+            as_json=False,
+        )
+        self.assertIn("created:", out)
+        self.assertIn("slug=foo", out)
+        self.assertIn("title=Foo Title", out)
+        self.assertIn("path=/tmp/foo.md", out)
+
+    def test_list_of_records_renders_numbered_with_count(self):
+        payload = {
+            "notes": [
+                {"slug": "alpha", "title": "Alpha", "type": "note"},
+                {"slug": "beta", "title": "Beta", "type": "decision"},
+            ]
+        }
+        out = _capture(payload, as_json=False)
+        self.assertIn("notes (2):", out)
+        self.assertIn("1. slug=alpha", out)
+        self.assertIn("title=Alpha", out)
+        self.assertIn("2. slug=beta", out)
+
+    def test_search_results_include_score(self):
+        payload = {
+            "query": "auth",
+            "results": [
+                {"slug": "auth-1", "title": "A1", "score": 0.123456},
+            ],
+        }
+        out = _capture(payload, as_json=False)
+        self.assertIn("query: auth", out)
+        self.assertIn("results (1):", out)
+        # score formatted to 3 decimals
+        self.assertIn("score=0.123", out)
+
+    def test_multiline_string_indents_each_line(self):
+        out = _capture({"body": "line one\nline two\nline three"}, as_json=False)
+        lines = out.splitlines()
+        self.assertEqual(lines[0], "body:")
+        self.assertEqual(lines[1], "  line one")
+        self.assertEqual(lines[2], "  line two")
+        self.assertEqual(lines[3], "  line three")
+
+    def test_nested_dict_without_summary_keys_expands(self):
+        payload = {"frontmatter": {"created_at": "2026-01-01", "tags": ["a", "b"]}}
+        out = _capture(payload, as_json=False)
+        self.assertIn("frontmatter:", out)
+        self.assertIn("created_at: 2026-01-01", out)
+
+    def test_empty_dict_prints_empty_marker(self):
+        out = _capture({}, as_json=False)
+        self.assertEqual(out.strip(), "(empty)")
+
+    def test_empty_list_field_prints_zero_count(self):
+        out = _capture({"backlinks": []}, as_json=False)
+        self.assertIn("backlinks (0):", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why
Both branches of `_print` previously emitted indented JSON, so the `--json` flag was a no-op for every `note` CLI verb (new, show, list, search, link, unlink, backlinks, graph, reindex, canvas) and for `hook install/uninstall/status`. Users had no way to ask for human-readable output.

## What
Non-JSON path walks the payload and prints:
- `key: value` for scalars
- `key: <key=value ...>` summary line for dicts that carry common identity keys (`slug`, `title`, `id`, `name`, `path`, `score`, `from`, `to`)
- `key (N):` header + numbered items for lists; each item collapsed to a one-line summary when possible
- `key:` header + indented lines for multi-line strings (note bodies)
- Nested dicts expand recursively when they don't have summary keys
- Floats formatted to 3 decimals

Example — `omnimem note search "auth" --limit 2`:
```
query: auth
results (2):
  1. slug=auth-decision-fastapi title=Why we chose FastAPI score=0.342
  2. slug=jwt-rotation title=JWT rotation policy score=0.481
```

## Test plan
- [x] `tests/test_print_human.py` — 9 cases pinning every shape the note CLI emits.
- [x] `python -m unittest discover -s tests` — 230 passed, 1 skipped.
- [x] Smoke: `omnimem note list` → readable text; `omnimem note list --json` → JSON.