### PR TITLE
perf(service): host notes + codemap collections in warm search service

### DIFF
--- a/omni_service.py
+++ b/omni_service.py
@@ -70,6 +70,10 @@ class _SearchServiceHandler(BaseHTTPRequestHandler):
                 return self._handle_add_records()
             if self.path == "/replace-core-records":
                 return self._handle_replace_core_records()
+            if self.path == "/notes/search":
+                return self._handle_notes_search()
+            if self.path == "/codemap/query":
+                return self._handle_codemap_query()
             self._send_json({"status": "not_found"}, status=404)
             return
 
@@ -132,10 +136,69 @@ class _SearchServiceHandler(BaseHTTPRequestHandler):
             return
         self._send_json({"status": "ok", **report})
 
+    def _handle_notes_search(self):
+        payload = self._read_json_payload()
+        if payload is None:
+            return
+        try:
+            runtime = _get_note_runtime_for_server(self.server)
+            records = runtime.search(
+                payload.get("query", ""),
+                n_results=int(payload.get("n_results", 5) or 5),
+                note_type=payload.get("note_type"),
+                tag=payload.get("tag"),
+                since=payload.get("since"),
+                until=payload.get("until"),
+            )
+        except Exception as exc:
+            self._send_json({"status": "fail", "detail": str(exc)}, status=500)
+            return
+        self._send_json({"status": "ok", "records": records})
+
+    def _handle_codemap_query(self):
+        payload = self._read_json_payload()
+        if payload is None:
+            return
+        try:
+            runtime = _get_codemap_runtime_for_server(self.server)
+            records = runtime.query(
+                payload.get("query", ""),
+                n_results=int(payload.get("n_results", 5) or 5),
+                kinds=payload.get("kinds"),
+            )
+        except Exception as exc:
+            self._send_json({"status": "fail", "detail": str(exc)}, status=500)
+            return
+        self._send_json({"status": "ok", "records": records})
+
     def log_message(self, fmt, *args):
         if getattr(self.server, "quiet", False):
             return
         super().log_message(fmt, *args)
+
+
+def _get_note_runtime_for_server(server):
+    """Lazily attach a NoteRuntime to the running service so the embedding
+    model is loaded once per process (not once per request)."""
+    runtime = getattr(server, "note_runtime", None)
+    if runtime is not None:
+        return runtime
+    from omni_note_index import NoteRuntime
+
+    server.note_runtime = NoteRuntime(root_dir=getattr(server, "root_dir", SOURCE_ROOT))
+    return server.note_runtime
+
+
+def _get_codemap_runtime_for_server(server):
+    runtime = getattr(server, "codemap_runtime", None)
+    if runtime is not None:
+        return runtime
+    from omni_codemap import CodemapRuntime
+
+    server.codemap_runtime = CodemapRuntime(
+        root_dir=getattr(server, "root_dir", SOURCE_ROOT)
+    )
+    return server.codemap_runtime
 
 
 def get_search_service_settings(root_dir=SOURCE_ROOT):
@@ -383,6 +446,74 @@ def add_records_via_service(
     return payload
 
 
+def search_notes_via_service(
+    query,
+    n_results=5,
+    note_type=None,
+    tag=None,
+    since=None,
+    until=None,
+    root_dir=SOURCE_ROOT,
+    autostart=True,
+):
+    settings = get_search_service_settings(root_dir=root_dir)
+    host = settings["host"]
+    port = settings["port"]
+    if not settings["enabled"]:
+        raise SearchServiceUnavailable("Search service is disabled by configuration")
+    if autostart:
+        ensure_search_service(root_dir=root_dir, host=host, port=port)
+    payload = _request_json(
+        "POST",
+        _build_service_url(host, port, "/notes/search"),
+        payload={
+            "query": query,
+            "n_results": n_results,
+            "note_type": note_type,
+            "tag": tag,
+            "since": since,
+            "until": until,
+        },
+        timeout_seconds=settings["request_timeout_seconds"],
+    )
+    if payload.get("status") != "ok":
+        raise SearchServiceProtocolError(
+            payload.get("detail") or "Unexpected /notes/search response"
+        )
+    return payload.get("records") or []
+
+
+def query_codemap_via_service(
+    query,
+    n_results=5,
+    kinds=None,
+    root_dir=SOURCE_ROOT,
+    autostart=True,
+):
+    settings = get_search_service_settings(root_dir=root_dir)
+    host = settings["host"]
+    port = settings["port"]
+    if not settings["enabled"]:
+        raise SearchServiceUnavailable("Search service is disabled by configuration")
+    if autostart:
+        ensure_search_service(root_dir=root_dir, host=host, port=port)
+    payload = _request_json(
+        "POST",
+        _build_service_url(host, port, "/codemap/query"),
+        payload={
+            "query": query,
+            "n_results": n_results,
+            "kinds": kinds,
+        },
+        timeout_seconds=settings["request_timeout_seconds"],
+    )
+    if payload.get("status") != "ok":
+        raise SearchServiceProtocolError(
+            payload.get("detail") or "Unexpected /codemap/query response"
+        )
+    return payload.get("records") or []
+
+
 def replace_core_records_via_service(
     records,
     root_dir=SOURCE_ROOT,
@@ -415,6 +546,7 @@ def run_search_service(host=None, port=None, quiet=False, root_dir=SOURCE_ROOT):
 
     runtime = OmniRuntime(root_dir=root_dir)
     server = _SearchServiceServer((host, port), _SearchServiceHandler)
+    server.root_dir = root_dir
     server.runtime = runtime
     server.runtime_signature = _get_runtime_signature(root_dir=root_dir)
     server.quiet = quiet

--- a/omnimem.py
+++ b/omnimem.py
@@ -406,12 +406,30 @@ def handle_note(args):
         if action == "search":
             at_date = getattr(args, "at_date", None)
             at_date_eod = _at_date_eod(at_date)
-            records = search_notes(
-                args.query,
-                n_results=(args.limit or 5) * (3 if at_date_eod else 1),
-                note_type=args.type,
-                tag=args.tag,
-            )
+            requested_n = (args.limit or 5) * (3 if at_date_eod else 1)
+            records = None
+            if not getattr(args, "direct", False):
+                try:
+                    from omni_service import (
+                        SearchServiceError,
+                        search_notes_via_service,
+                    )
+
+                    records = search_notes_via_service(
+                        args.query,
+                        n_results=requested_n,
+                        note_type=args.type,
+                        tag=args.tag,
+                    )
+                except SearchServiceError:
+                    records = None
+            if records is None:
+                records = search_notes(
+                    args.query,
+                    n_results=requested_n,
+                    note_type=args.type,
+                    tag=args.tag,
+                )
             if at_date_eod:
                 records = [
                     record
@@ -638,11 +656,24 @@ def handle_codemap(args):
         if args.codemap_command == "query":
             local_results = query_local_index(args.query, limit=args.limit or 20)
             semantic_results = []
-            try:
-                runtime = CodemapRuntime()
-                semantic_results = runtime.query(args.query, n_results=args.limit or 5)
-            except Exception:
-                semantic_results = []
+            if not getattr(args, "direct", False):
+                try:
+                    from omni_service import (
+                        SearchServiceError,
+                        query_codemap_via_service,
+                    )
+
+                    semantic_results = query_codemap_via_service(
+                        args.query, n_results=args.limit or 5
+                    )
+                except SearchServiceError:
+                    semantic_results = []
+            if not semantic_results:
+                try:
+                    runtime = CodemapRuntime()
+                    semantic_results = runtime.query(args.query, n_results=args.limit or 5)
+                except Exception:
+                    semantic_results = []
             _print({"local": local_results, "semantic": semantic_results}, as_json)
             return 0
         if args.codemap_command == "rm":
@@ -1036,6 +1067,11 @@ def build_parser():
     note_search.add_argument("--at-date", dest="at_date", help="Filter to notes created at or before this YYYY-MM-DD")
     note_search.add_argument("--limit", type=int)
     note_search.add_argument("--full", action="store_true")
+    note_search.add_argument(
+        "--direct",
+        action="store_true",
+        help="Bypass the warm search service and run the one-shot path directly",
+    )
     note_search.add_argument("--json", action="store_true")
 
     note_link = note_subparsers.add_parser("link", help="Add a wikilink between notes")
@@ -1114,6 +1150,11 @@ def build_parser():
     codemap_query.add_argument("query")
     codemap_query.add_argument("--limit", type=int)
     codemap_query.add_argument("--json", action="store_true")
+    codemap_query.add_argument(
+        "--direct",
+        action="store_true",
+        help="Bypass the warm search service and run the one-shot path directly",
+    )
 
     codemap_rm = codemap_subparsers.add_parser("rm", help="Delete the codemap for a repo")
     codemap_rm.add_argument("repo_name")

--- a/tests/test_service_notes_codemap.py
+++ b/tests/test_service_notes_codemap.py
@@ -1,0 +1,242 @@
+"""Verify the warm search service hosts the notes and codemap collections.
+
+Before this change, the warm service only served `omnimem_core` (imports).
+`note search` and `codemap query` had to spin up their own NoteRuntime /
+CodemapRuntime in-process, which meant reloading the embedding model on
+every CLI invocation. These tests pin both halves of the contract:
+
+- Server side: POST /notes/search and POST /codemap/query proxy to
+  cached NoteRuntime / CodemapRuntime instances stored on the server.
+- Client side: search_notes_via_service and query_codemap_via_service
+  raise SearchServiceUnavailable when the service is disabled, and emit
+  the right JSON body when it's reachable.
+"""
+
+import json
+import unittest
+from io import BytesIO
+from unittest.mock import patch
+
+import omni_service
+
+
+class _RecordingHandler:
+    """Bare-minimum stand-in for BaseHTTPRequestHandler."""
+
+    def __init__(self, server, body):
+        self.server = server
+        self.path = None
+        self.headers = {"Content-Length": str(len(body))}
+        self.rfile = BytesIO(body)
+        self.wfile = BytesIO()
+        self.status = None
+        self.response_headers = []
+        self.payload = None
+
+    # --- methods used by _SearchServiceHandler ---
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, name, value):
+        self.response_headers.append((name, value))
+
+    def end_headers(self):
+        pass
+
+    def _send_json(self, payload, status=200):
+        self.payload = payload
+        self.status = status
+
+    def _read_json_payload(self):
+        raw = self.rfile.read()
+        try:
+            return json.loads(raw.decode("utf-8") if raw else "{}")
+        except json.JSONDecodeError:
+            self._send_json({"status": "fail", "detail": "Invalid JSON body"}, status=400)
+            return None
+
+
+class _FakeNoteRuntime:
+    instances = 0
+
+    def __init__(self, root_dir=None):
+        type(self).instances += 1
+        self.root_dir = root_dir
+        self.calls = []
+
+    def search(self, query, n_results=5, note_type=None, tag=None, since=None, until=None):
+        self.calls.append(
+            {
+                "query": query,
+                "n_results": n_results,
+                "note_type": note_type,
+                "tag": tag,
+                "since": since,
+                "until": until,
+            }
+        )
+        return [{"id": "n1", "document": "note body", "metadata": {"slug": "n1"}, "distance": 0.2}]
+
+
+class _FakeCodemapRuntime:
+    instances = 0
+
+    def __init__(self, root_dir=None):
+        type(self).instances += 1
+        self.root_dir = root_dir
+        self.calls = []
+
+    def query(self, query, n_results=5, kinds=None):
+        self.calls.append({"query": query, "n_results": n_results, "kinds": kinds})
+        return [{"id": "c1", "document": "alpha", "metadata": {"name": "alpha"}, "distance": 0.4}]
+
+
+class _FakeServer:
+    def __init__(self, root_dir="/tmp/vault"):
+        self.root_dir = root_dir
+
+
+class TestNotesSearchEndpoint(unittest.TestCase):
+    def setUp(self):
+        _FakeNoteRuntime.instances = 0
+
+    def test_returns_records_from_note_runtime(self):
+        server = _FakeServer()
+        handler = _RecordingHandler(server, body=json.dumps({"query": "hello"}).encode("utf-8"))
+
+        with patch("omni_note_index.NoteRuntime", _FakeNoteRuntime):
+            omni_service._SearchServiceHandler._handle_notes_search(handler)
+
+        self.assertEqual(handler.status, 200)
+        self.assertEqual(handler.payload["status"], "ok")
+        self.assertEqual(len(handler.payload["records"]), 1)
+        self.assertEqual(handler.payload["records"][0]["id"], "n1")
+
+    def test_caches_note_runtime_on_server(self):
+        server = _FakeServer()
+        body = json.dumps({"query": "hello"}).encode("utf-8")
+
+        with patch("omni_note_index.NoteRuntime", _FakeNoteRuntime):
+            for _ in range(3):
+                handler = _RecordingHandler(server, body=body)
+                omni_service._SearchServiceHandler._handle_notes_search(handler)
+        # Three requests, one runtime construction
+        self.assertEqual(_FakeNoteRuntime.instances, 1)
+        # And the cached runtime saw all 3 calls
+        self.assertEqual(len(server.note_runtime.calls), 3)
+
+
+class TestCodemapQueryEndpoint(unittest.TestCase):
+    def setUp(self):
+        _FakeCodemapRuntime.instances = 0
+
+    def test_returns_records_from_codemap_runtime(self):
+        server = _FakeServer()
+        handler = _RecordingHandler(server, body=json.dumps({"query": "alpha"}).encode("utf-8"))
+
+        with patch("omni_codemap.CodemapRuntime", _FakeCodemapRuntime):
+            omni_service._SearchServiceHandler._handle_codemap_query(handler)
+
+        self.assertEqual(handler.status, 200)
+        self.assertEqual(handler.payload["status"], "ok")
+        self.assertEqual(handler.payload["records"][0]["id"], "c1")
+
+    def test_caches_codemap_runtime_on_server(self):
+        server = _FakeServer()
+        body = json.dumps({"query": "alpha"}).encode("utf-8")
+
+        with patch("omni_codemap.CodemapRuntime", _FakeCodemapRuntime):
+            for _ in range(2):
+                handler = _RecordingHandler(server, body=body)
+                omni_service._SearchServiceHandler._handle_codemap_query(handler)
+        self.assertEqual(_FakeCodemapRuntime.instances, 1)
+
+
+class TestSearchNotesViaService(unittest.TestCase):
+    def test_disabled_settings_raises_unavailable(self):
+        with patch.object(
+            omni_service,
+            "get_search_service_settings",
+            return_value={"enabled": False, "host": "127.0.0.1", "port": 1, "request_timeout_seconds": 1, "startup_timeout_seconds": 1},
+        ):
+            with self.assertRaises(omni_service.SearchServiceUnavailable):
+                omni_service.search_notes_via_service("hello", autostart=False)
+
+    def test_posts_expected_payload(self):
+        captured = {}
+
+        def _fake_request(method, url, payload=None, timeout_seconds=None):
+            captured["url"] = url
+            captured["payload"] = payload
+            return {"status": "ok", "records": [{"id": "n1"}]}
+
+        with patch.object(
+            omni_service,
+            "get_search_service_settings",
+            return_value={
+                "enabled": True,
+                "host": "127.0.0.1",
+                "port": 41733,
+                "request_timeout_seconds": 5,
+                "startup_timeout_seconds": 5,
+            },
+        ), patch.object(omni_service, "_request_json", _fake_request):
+            records = omni_service.search_notes_via_service(
+                "hello",
+                n_results=7,
+                note_type="decision",
+                tag="release",
+                autostart=False,
+            )
+        self.assertEqual(records, [{"id": "n1"}])
+        self.assertTrue(captured["url"].endswith("/notes/search"))
+        self.assertEqual(captured["payload"]["query"], "hello")
+        self.assertEqual(captured["payload"]["n_results"], 7)
+        self.assertEqual(captured["payload"]["note_type"], "decision")
+        self.assertEqual(captured["payload"]["tag"], "release")
+
+
+class TestQueryCodemapViaService(unittest.TestCase):
+    def test_disabled_settings_raises_unavailable(self):
+        with patch.object(
+            omni_service,
+            "get_search_service_settings",
+            return_value={"enabled": False, "host": "127.0.0.1", "port": 1, "request_timeout_seconds": 1, "startup_timeout_seconds": 1},
+        ):
+            with self.assertRaises(omni_service.SearchServiceUnavailable):
+                omni_service.query_codemap_via_service("alpha", autostart=False)
+
+    def test_posts_expected_payload(self):
+        captured = {}
+
+        def _fake_request(method, url, payload=None, timeout_seconds=None):
+            captured["url"] = url
+            captured["payload"] = payload
+            return {"status": "ok", "records": [{"id": "c1"}]}
+
+        with patch.object(
+            omni_service,
+            "get_search_service_settings",
+            return_value={
+                "enabled": True,
+                "host": "127.0.0.1",
+                "port": 41733,
+                "request_timeout_seconds": 5,
+                "startup_timeout_seconds": 5,
+            },
+        ), patch.object(omni_service, "_request_json", _fake_request):
+            records = omni_service.query_codemap_via_service(
+                "alpha",
+                n_results=3,
+                kinds=["function", "class"],
+                autostart=False,
+            )
+        self.assertEqual(records, [{"id": "c1"}])
+        self.assertTrue(captured["url"].endswith("/codemap/query"))
+        self.assertEqual(captured["payload"]["query"], "alpha")
+        self.assertEqual(captured["payload"]["n_results"], 3)
+        self.assertEqual(captured["payload"]["kinds"], ["function", "class"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why
The warm service only proxied `omnimem_core` (imports). CLI invocations of `omnimem note search` and `omnimem codemap query` always went the in-process path, which loads the embedding model and builds a fresh ChromaDB client every call — exactly the cost the warm service was supposed to amortize.

## What

### Server side
- `omni_service.py` adds `POST /notes/search` and `POST /codemap/query`. Each handler lazy-attaches a `NoteRuntime` / `CodemapRuntime` to the running server so the model is loaded once per service process.
- `run_search_service` now stores `root_dir` on the server object so the lazy helpers can build runtimes against the correct vault.

### Client side
- New `search_notes_via_service` and `query_codemap_via_service` mirroring the existing `search_via_service` / `add_records_via_service` shape.

### CLI
- `note search` and `codemap query` try the warm service first and fall back to direct on `SearchServiceUnavailable`. New `--direct` flag on both subcommands matches the existing pattern on `search` / `add` / `import` / `reindex`.

## Effect
A session that runs `omnimem note search` or `omnimem codemap query` from multiple terminal tabs now reuses the warm service's resident model — saving the ~1-2s model load per call.

End-to-end smoke (after killing the old service so the new endpoints kick in on auto-restart):
```
$ omnimem note search "release" --limit 2 --json
   ← no "Loading weights" tqdm; results returned in ~50ms
$ omnimem codemap query "OmniRuntime" --limit 1
   ← same; service-side model stays warm
```

## Test plan
- [x] `tests/test_service_notes_codemap.py` — 8 cases pinning runtime caching for both endpoints + client request shape + disabled-service short-circuit.
- [x] `python -m unittest discover -s tests` — 238 passed, 1 skipped, 0 failed.
- [x] Live smoke: kill warm service, run `note search` and `codemap query`, confirm sub-second latency on 2nd call.

## Backward compatibility
Pure-additive on the wire (existing `/search`, `/add-records`, `/replace-core-records` unchanged). Existing CLI flags unchanged; `--direct` is opt-in. Older clients hitting an upgraded service ignore the new endpoints. Newer clients hitting an older service get `404 not_found` and silently fall back to the in-process path.