### PR TITLE
ci: expand matrix to Ubuntu/Windows/macOS x Python 3.10/3.11/3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,13 @@ on:
 
 jobs:
   quality:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.10", "3.11", "3.12"]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout
@@ -17,20 +23,28 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
 
       - name: Compile Python files
+        shell: bash
         run: |
           python -m compileall \
             omnimem.py \
             omni_add.py \
             omni_search.py \
+            omni_search_core.py \
+            omni_service.py \
             omni_import.py \
             omni_del.py \
             omni_bootstrap.py \
             omni_doctor.py \
             omni_metadata.py \
             omni_paths.py \
+            omni_config.py \
+            omni_chunking.py \
+            omni_embeddings.py \
+            omni_ops.py \
+            omni_reindex.py \
             omni_update.py \
             omni_version.py \
             omni_init.py \
@@ -50,7 +64,9 @@ jobs:
             benchmarks/bench_retrieval.py \
             benchmarks/run_all.py
 
-      - name: Validate shell setup script
+      - name: Validate shell setup scripts
+        if: runner.os != 'Windows'
+        shell: bash
         run: |
           bash -n setup.sh
           bash -n omnimem
@@ -59,6 +75,8 @@ jobs:
         run: python -m pip install --upgrade pip pyyaml
 
       - name: Run unit tests
+        env:
+          PYTHONIOENCODING: utf-8
         run: python -m unittest discover -s tests -v
 
       - name: Install packaging tool
@@ -68,13 +86,21 @@ jobs:
         run: python -m build
 
       - name: Smoke test installed console entry point
+        shell: bash
         run: |
           python -m venv .pkg-smoke
-          . .pkg-smoke/bin/activate
-          python -m pip install --upgrade pip
-          python -m pip install --no-deps dist/*.whl
-          omnimem --version
-          python - <<'PY'
+          if [ -f .pkg-smoke/bin/python ]; then
+            VENV_PY=.pkg-smoke/bin/python
+            VENV_OMNIMEM=.pkg-smoke/bin/omnimem
+          else
+            VENV_PY=.pkg-smoke/Scripts/python.exe
+            VENV_OMNIMEM=.pkg-smoke/Scripts/omnimem.exe
+          fi
+          "$VENV_PY" -m pip install --upgrade pip
+          WHEEL=$(ls dist/*.whl | head -n 1)
+          "$VENV_PY" -m pip install --no-deps "$WHEEL"
+          "$VENV_OMNIMEM" --version
+          "$VENV_PY" - <<'PY'
           import json
           import subprocess
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,17 +90,19 @@ jobs:
         run: |
           python -m venv .pkg-smoke
           if [ -f .pkg-smoke/bin/python ]; then
-            VENV_PY=.pkg-smoke/bin/python
-            VENV_OMNIMEM=.pkg-smoke/bin/omnimem
+            VENV_BIN=$(cd .pkg-smoke/bin && pwd)
           else
-            VENV_PY=.pkg-smoke/Scripts/python.exe
-            VENV_OMNIMEM=.pkg-smoke/Scripts/omnimem.exe
+            VENV_BIN=$(cd .pkg-smoke/Scripts && pwd)
           fi
-          "$VENV_PY" -m pip install --upgrade pip
+          # Put the venv on PATH so the heredoc's `omnimem` lookup hits the
+          # newly-installed entry point (we never `source activate` because
+          # that script differs between bash / pwsh / cmd).
+          export PATH="$VENV_BIN:$PATH"
+          python -m pip install --upgrade pip
           WHEEL=$(ls dist/*.whl | head -n 1)
-          "$VENV_PY" -m pip install --no-deps "$WHEEL"
-          "$VENV_OMNIMEM" --version
-          "$VENV_PY" - <<'PY'
+          python -m pip install --no-deps "$WHEEL"
+          omnimem --version
+          python - <<'PY'
           import json
           import subprocess
 


### PR DESCRIPTION
## Why
Previous CI ran only on `ubuntu-latest` with Python 3.10. v1.2.5 shipped Windows-specific fixes (cp1252 stdout reconfigure, 8.3 short-name path normalization, POSIX hook path quoting) that were never verified by CI on a real Windows runner. macOS was equally untested.

## What
- 3 OS × 3 Python versions = 9 cells. `fail-fast: false` so one bad cell doesn't abort the rest.
- Bash-only steps pinned with `shell: bash` (works on Windows via Git Bash that ships with the runner).
- Package smoke step detects venv layout (`bin/` on POSIX, `Scripts/` on Windows).
- `setup.sh` syntax check gated to non-Windows (the script is bash-only by design; Windows users run `setup.ps1`).
- Compileall list extended with modules added since the original workflow (`omni_search_core`, `omni_service`, `omni_config`, `omni_chunking`, `omni_embeddings`, `omni_ops`, `omni_reindex`).

## Expected outcome
This PR's CI run **is the actual verification**. If a cell fails, that's a real cross-platform bug we need to fix before claiming v1.2.5 runs on every OS.