### PR TITLE
fix: stdin UTF-8 + docs sync to actual hook CLI syntax

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -20,7 +20,7 @@ If you'd rather wire one specific CLI by hand:
 
 ```bash
 ./omnimem init --agent claude
-./omnimem hook install --agent claude
+./omnimem hook --agent claude
 # Restart Claude Code. The omnimem_* tools should appear in `/mcp`.
 ```
 
@@ -28,7 +28,7 @@ If you'd rather wire one specific CLI by hand:
 
 ```bash
 ./omnimem init --agent codex
-./omnimem hook install --agent codex
+./omnimem hook --agent codex
 # Restart Codex. AGENTS.md is read on session start.
 ```
 
@@ -50,7 +50,7 @@ If you'd rather wire one specific CLI by hand:
 
 ```bash
 ./omnimem init --agent all
-./omnimem hook install --agent all
+./omnimem hook --agent all
 ```
 
 The installer is **idempotent and reversible**:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ OmniMem is an LLM-agnostic, multimodal second brain running purely in the termin
 1. **Document RAG** — ingest PDFs, Word files, source code, and OCR images via Kreuzberg + ChromaDB.
 2. **Structured notes** — Zettelkasten-style notes in a portable Markdown vault with bi-directional wikilinks.
 3. **Codemap** — `omnimem codemap build` walks a repo and writes a structural map per source file. Supports Python (stdlib `ast`), JavaScript, TypeScript, Go, and Rust via the parser registry, with per-symbol records in ChromaDB.
-4. **One-command integration** — `omnimem init --agent claude|codex|gemini|cursor|all` wires OmniMem into each agent's instructions file and MCP config; `omnimem hook install --agent claude|codex|all` adds lifecycle hooks for both Claude Code and Codex CLI.
+4. **One-command integration** — `omnimem init --agent claude|codex|gemini|cursor|all` wires OmniMem into each agent's instructions file and MCP config; `omnimem hook --agent claude|codex|all` adds lifecycle hooks for both Claude Code and Codex CLI.
 5. **Federated search + temporal queries** — `omnimem search --all` ranks results from imported documents, structured notes, and codemap symbols together. `--at-date YYYY-MM-DD` reconstructs the state of the vault as of a given day.
 6. **Canvas export + secret redaction** — `omnimem note canvas` exports the note graph as Obsidian Canvas JSON. `omnimem redact` scans text for AWS / GitHub / OpenAI / Anthropic tokens, PEM blocks, JWTs, and the obvious credential shapes.
 
@@ -131,7 +131,7 @@ This is intended for users who imported files on older OmniMem releases and want
 
 ## How to wire OmniMem into your agent CLI
 
-**Prefer the one-command install** — `omnimem init` writes the rule block, registers the MCP server, and (with `omnimem hook install`) sets up lifecycle hooks. No manual prompt editing required.
+**Prefer the one-command install** — `omnimem init` writes the rule block, registers the MCP server, and (with `omnimem hook`) sets up lifecycle hooks. No manual prompt editing required.
 
 ### Recommended: interactive wizard
 
@@ -144,18 +144,18 @@ This is intended for users who imported files on older OmniMem releases and want
 
 | Agent | Command |
 |---|---|
-| Claude Code | `./omnimem init --agent claude && ./omnimem hook install --agent claude` |
-| Codex CLI | `./omnimem init --agent codex && ./omnimem hook install --agent codex` |
+| Claude Code | `./omnimem init --agent claude && ./omnimem hook --agent claude` |
+| Codex CLI | `./omnimem init --agent codex && ./omnimem hook --agent codex` |
 | Gemini CLI | `./omnimem init --agent gemini` |
 | Cursor | `./omnimem init --agent cursor` |
-| All four | `./omnimem init --agent all && ./omnimem hook install --agent all` |
+| All four | `./omnimem init --agent all && ./omnimem hook --agent all` |
 
 What `init` does:
 - Writes a marked rule block (`<!-- OMNIMEM:START v1.2 -->` ... `<!-- OMNIMEM:END -->`) into the agent's instructions file (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, or `.cursor/rules/omnimem.mdc`). Existing content is preserved.
 - Registers the OmniMem MCP server in the agent's MCP config (`mcp.json` for Claude Code / Cursor, `settings.json` for Gemini, `config.toml` for Codex).
 - Idempotent: re-running replaces only the marked block. Reversible: `./omnimem init --uninstall --agent <agent>` strips it cleanly.
 
-What `hook install` does (Claude Code + Codex CLI only):
+What `omnimem hook` does (Claude Code + Codex CLI only):
 - `SessionStart` → injects the most recent notes so the agent has fresh project context.
 - `Stop` → lists today's notes so the agent reflects on what was just completed.
 - `PostToolUse` (Edit / Write / MultiEdit) → triggers `omnimem note reindex` so any edited markdown re-syncs into ChromaDB.

--- a/README_ru.md
+++ b/README_ru.md
@@ -15,7 +15,7 @@ OmniMem — это мультимодальный «второй мозг», LLM
 1. **Document RAG** — ингестит PDF, Word, исходный код и OCR-картинки через Kreuzberg + ChromaDB.
 2. **Структурированные заметки** — заметки в стиле Zettelkasten в переносимом Markdown-хранилище с двунаправленными wiki-ссылками.
 3. **Codemap** — `omnimem codemap build` обходит репозиторий и пишет структурную карту для каждого исходного файла. Поддерживает Python (stdlib `ast`), JavaScript, TypeScript, Go и Rust через реестр парсеров, с записями отдельных символов в ChromaDB.
-4. **Интеграция одной командой** — `omnimem init --agent claude|codex|gemini|cursor|all` прописывает правило в файл инструкций агента + регистрирует MCP-сервер; `omnimem hook install --agent claude|codex|all` добавляет lifecycle-хуки для Claude Code и Codex CLI.
+4. **Интеграция одной командой** — `omnimem init --agent claude|codex|gemini|cursor|all` прописывает правило в файл инструкций агента + регистрирует MCP-сервер; `omnimem hook --agent claude|codex|all` добавляет lifecycle-хуки для Claude Code и Codex CLI.
 5. **Объединённый поиск + временные запросы** — `omnimem search --all` ранжирует результаты из документов, заметок и codemap-символов вместе. `--at-date YYYY-MM-DD` восстанавливает состояние хранилища на конкретный день.
 6. **Canvas-экспорт + редакция секретов** — `omnimem note canvas` экспортирует граф заметок в формате Obsidian Canvas JSON. `omnimem redact` сканирует текст на токены AWS / GitHub / OpenAI / Anthropic, PEM-блоки, JWT и типичные шаблоны учётных данных.
 
@@ -71,11 +71,11 @@ curl -fsSL https://raw.githubusercontent.com/manhlinhfs/omnimem/main/install.sh 
 
 | Агент | Команда |
 |---|---|
-| Claude Code | `./omnimem init --agent claude && ./omnimem hook install --agent claude` |
-| Codex CLI | `./omnimem init --agent codex && ./omnimem hook install --agent codex` |
+| Claude Code | `./omnimem init --agent claude && ./omnimem hook --agent claude` |
+| Codex CLI | `./omnimem init --agent codex && ./omnimem hook --agent codex` |
 | Gemini CLI | `./omnimem init --agent gemini` |
 | Cursor | `./omnimem init --agent cursor` |
-| Все сразу | `./omnimem init --agent all && ./omnimem hook install --agent all` |
+| Все сразу | `./omnimem init --agent all && ./omnimem hook --agent all` |
 
 Установщик **идемпотентен и обратим**:
 

--- a/README_vi.md
+++ b/README_vi.md
@@ -15,7 +15,7 @@ OmniMem là "bộ não thứ hai" multimodal, LLM-agnostic, chạy hoàn toàn t
 1. **Document RAG** — ingest PDF, Word, source code và ảnh OCR qua Kreuzberg + ChromaDB.
 2. **Note có cấu trúc** — note kiểu Zettelkasten trong vault Markdown portable, có wikilink hai chiều.
 3. **Codemap** — `omnimem codemap build` quét repo, viết structural map cho từng source file. Hỗ trợ Python (stdlib `ast`), JavaScript, TypeScript, Go và Rust qua parser registry, có per-symbol record trong ChromaDB.
-4. **Tích hợp một lệnh** — `omnimem init --agent claude|codex|gemini|cursor|all` ghi rule vào instructions file của từng agent + đăng ký MCP server; `omnimem hook install --agent claude|codex|all` thêm lifecycle hook cho Claude Code và Codex CLI.
+4. **Tích hợp một lệnh** — `omnimem init --agent claude|codex|gemini|cursor|all` ghi rule vào instructions file của từng agent + đăng ký MCP server; `omnimem hook --agent claude|codex|all` thêm lifecycle hook cho Claude Code và Codex CLI.
 5. **Federated search + truy vấn theo thời gian** — `omnimem search --all` xếp hạng kết quả từ documents, structured notes, và codemap symbols cùng nhau. `--at-date YYYY-MM-DD` tái dựng trạng thái vault tại một ngày cụ thể.
 6. **Canvas export + redact secret** — `omnimem note canvas` xuất note graph dạng Obsidian Canvas JSON. `omnimem redact` quét text tìm AWS / GitHub / OpenAI / Anthropic token, PEM key, JWT, và các chuỗi credential phổ biến.
 
@@ -71,11 +71,11 @@ Mỗi agent một dòng. Wizard `omnimem quickstart` lo hết, hoặc làm tay:
 
 | Agent | Lệnh |
 |---|---|
-| Claude Code | `./omnimem init --agent claude && ./omnimem hook install --agent claude` |
-| Codex CLI | `./omnimem init --agent codex && ./omnimem hook install --agent codex` |
+| Claude Code | `./omnimem init --agent claude && ./omnimem hook --agent claude` |
+| Codex CLI | `./omnimem init --agent codex && ./omnimem hook --agent codex` |
 | Gemini CLI | `./omnimem init --agent gemini` |
 | Cursor | `./omnimem init --agent cursor` |
-| Cài hết một lượt | `./omnimem init --agent all && ./omnimem hook install --agent all` |
+| Cài hết một lượt | `./omnimem init --agent all && ./omnimem hook --agent all` |
 
 Installer **idempotent và reversible**:
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -84,7 +84,7 @@ This benchmark is therefore most useful as a **floor test**: any future change t
 ## Caveats and roadmap
 
 - **No third-party comparison yet.** Mem0 publishes LOCOMO numbers. We do not run the same dataset, so apples-to-apples claims are intentionally avoided.
-- **No e2e against real agent CLIs.** `omnimem init`, `omnimem hook install`, and the MCP server are exercised by unit tests but not by spawning an actual Claude Code / Codex / Gemini / Cursor session in the benchmark suite. Manual checks live in each PR's test plan.
+- **No e2e against real agent CLIs.** `omnimem init`, `omnimem hook`, and the MCP server are exercised by unit tests but not by spawning an actual Claude Code / Codex / Gemini / Cursor session in the benchmark suite. Manual checks live in each PR's test plan.
 - **No load test.** The latency numbers reflect single-threaded sequential calls. Concurrent ingest/search performance is not characterized.
 - **Single hardware sample.** The numbers come from one developer machine; CI does not yet run the benchmarks.
 

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -34,7 +34,7 @@ Indexing produces both:
 omnimem codemap update /path/to/repo/src/auth.py --repo-path /path/to/repo
 ```
 
-Re-parses one source file in place. Use this from a `PostToolUse` hook (see `omnimem hook install`) so the codemap stays current as code changes.
+Re-parses one source file in place. Use this from a `PostToolUse` hook (see `omnimem hook`) so the codemap stays current as code changes.
 
 ### Query symbols
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,7 +2,7 @@
 
 ## Is this really offline?
 
-Yes. After `setup.sh` bootstraps the embedding model, every command (`add`, `import`, `note`, `search`, `codemap`, `mcp serve`, `init`, `hook install`) runs without network access. ChromaDB lives on your disk, the embedding model lives in `$OMNIMEM_HOME/.omnimem_models/`, and Kreuzberg parses files locally.
+Yes. After `setup.sh` bootstraps the embedding model, every command (`add`, `import`, `note`, `search`, `codemap`, `mcp serve`, `init`, `hook`) runs without network access. ChromaDB lives on your disk, the embedding model lives in `$OMNIMEM_HOME/.omnimem_models/`, and Kreuzberg parses files locally.
 
 The only network step is the initial model download (~22MB for `all-MiniLM-L6-v2`). After that, you can `unplug` the network and OmniMem still works.
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,6 +1,6 @@
 # OmniMem Lifecycle Hooks
 
-`omnimem hook install` wires OmniMem into an agent CLI's lifecycle so the agent doesn't have to remember to call OmniMem on every turn. v1.2 supports Claude Code (`~/.claude/settings.json`) and Codex CLI (`~/.codex/config.toml`).
+`omnimem hook` wires OmniMem into an agent CLI's lifecycle so the agent doesn't have to remember to call OmniMem on every turn. v1.2 supports Claude Code (`~/.claude/settings.json`) and Codex CLI (`~/.codex/config.toml`).
 
 ## Supported events (Claude Code)
 
@@ -15,7 +15,7 @@ Each entry is tagged with `"tag": "omnimem-v1"` inside the hook so reinstalling 
 ## Install
 
 ```bash
-omnimem hook install --agent claude
+omnimem hook --agent claude
 ```
 
 This writes (or updates) `~/.claude/settings.json` `hooks` section with all default events.
@@ -23,13 +23,13 @@ This writes (or updates) `~/.claude/settings.json` `hooks` section with all defa
 To install only a subset:
 
 ```bash
-omnimem hook install --agent claude --event SessionStart --event Stop
+omnimem hook --agent claude --event SessionStart --event Stop
 ```
 
 To install for the current project only:
 
 ```bash
-omnimem hook install --agent claude --scope project
+omnimem hook --agent claude --scope project
 ```
 
 ## Status
@@ -83,7 +83,7 @@ command = "..."
 Install / uninstall with:
 
 ```bash
-omnimem hook install --agent codex
+omnimem hook --agent codex
 omnimem hook --uninstall --agent codex
 ```
 
@@ -92,7 +92,7 @@ If your Codex version expects different hook section names or schema, edit the b
 ## Install for both agents
 
 ```bash
-omnimem hook install --agent all
+omnimem hook --agent all
 omnimem hook --status
 omnimem hook --uninstall --agent all
 ```

--- a/omni_hooks.py
+++ b/omni_hooks.py
@@ -1,9 +1,9 @@
 """Lifecycle hook installer for OmniMem.
 
-`omnimem hook install` wires OmniMem into an agent CLI's lifecycle so the
-agent does not have to remember to call OmniMem on every turn. v2.0 ships
-support for Claude Code's `settings.json` hook section. Codex CLI hooks land
-once their lifecycle API is stable.
+`omnimem hook --agent claude|codex` wires OmniMem into an agent CLI's
+lifecycle so the agent does not have to remember to call OmniMem on every
+turn. v2.0 ships support for Claude Code's `settings.json` hook section.
+Codex CLI hooks land once their lifecycle API is stable.
 """
 
 import json

--- a/omni_quickstart.py
+++ b/omni_quickstart.py
@@ -190,9 +190,9 @@ def run(
                     )
                     out.write(f"  {_tick(out)} Installed hooks for {len(hook_results)} agent(s).\n")
                 except Exception as exc:
-                    out.write(f"  {_cross(out)} hook install failed: {exc}\n")
+                    out.write(f"  {_cross(out)} hook installation failed: {exc}\n")
             else:
-                out.write("Skipped hook install.\n")
+                out.write("Skipped hook installation.\n")
 
     welcome_record = None
     if seed_note:

--- a/omnimem.py
+++ b/omnimem.py
@@ -1187,7 +1187,7 @@ def build_parser():
         help=(
             "Internal: read a PostToolUse hook payload from stdin and only "
             "reindex notes when the touched file lives inside the vault. "
-            "Used by `hook install`'s recipe."
+            "Used by `omnimem hook`'s installed PostToolUse recipe."
         ),
     )
     hook_parser.set_defaults(handler=handle_hook)
@@ -1243,7 +1243,11 @@ def build_parser():
 
 
 def _force_utf8_streams():
-    for stream in (sys.stdout, sys.stderr):
+    # stdin matters for `note new --body -` and similar verbs that read body
+    # text from a heredoc. On Windows, the default cp1252 decoder turns any
+    # non-cp1252 byte into a surrogate via `surrogateescape`, and the surrogate
+    # then blows up at write time with "surrogates not allowed".
+    for stream in (sys.stdout, sys.stderr, sys.stdin):
         reconfigure = getattr(stream, "reconfigure", None)
         if callable(reconfigure):
             try:

--- a/tests/test_hook_path_quoting.py
+++ b/tests/test_hook_path_quoting.py
@@ -1,6 +1,6 @@
 """Regression test for the Windows hook-path bug in v1.2.1 / v1.2.2.
 
-`omnimem hook install` writes the Python interpreter path into Claude Code's
+`omnimem hook --agent claude` writes the Python interpreter path into Claude Code's
 `settings.json`. On Windows `sys.executable` returns
 `C:\\Users\\...\\python.exe` (backslashes). Claude Code passes hook commands
 through `bash -c`, which interprets backslashes as escape characters and

--- a/tests/test_stdin_utf8.py
+++ b/tests/test_stdin_utf8.py
@@ -1,0 +1,66 @@
+"""Verify `_force_utf8_streams` reconfigures stdin (not just stdout/stderr).
+
+On Windows the default stdin decoder is cp1252 with `surrogateescape`, so a
+heredoc that pipes UTF-8 bytes (e.g. Vietnamese diacritics) into
+`omnimem note new --body -` produced surrogates that crashed
+`Path.write_text` later with "surrogates not allowed".
+
+PR #6 (v1.2.5) reconfigured stdout/stderr to UTF-8 but missed stdin. This
+test pins the wider contract: all three standard streams get UTF-8
+encoding when `_force_utf8_streams` runs.
+"""
+
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+import omnimem
+
+
+class TestForceUtf8Streams(unittest.TestCase):
+    def test_reconfigure_called_on_all_three_streams(self):
+        original = (sys.stdin, sys.stdout, sys.stderr)
+        try:
+            stdin = MagicMock()
+            stdout = MagicMock()
+            stderr = MagicMock()
+            sys.stdin, sys.stdout, sys.stderr = stdin, stdout, stderr
+
+            omnimem._force_utf8_streams()
+
+            stdin.reconfigure.assert_called_once_with(encoding="utf-8")
+            stdout.reconfigure.assert_called_once_with(encoding="utf-8")
+            stderr.reconfigure.assert_called_once_with(encoding="utf-8")
+        finally:
+            sys.stdin, sys.stdout, sys.stderr = original
+
+    def test_streams_without_reconfigure_are_skipped_quietly(self):
+        original = (sys.stdin, sys.stdout, sys.stderr)
+        try:
+            class _BareStream:
+                """Looks like a closed/redirected stream that lacks reconfigure."""
+
+            sys.stdin = _BareStream()
+            sys.stdout = _BareStream()
+            sys.stderr = _BareStream()
+            # Should not raise.
+            omnimem._force_utf8_streams()
+        finally:
+            sys.stdin, sys.stdout, sys.stderr = original
+
+    def test_reconfigure_failure_is_swallowed(self):
+        original = (sys.stdin, sys.stdout, sys.stderr)
+        try:
+            stream = MagicMock()
+            stream.reconfigure.side_effect = ValueError("can't change encoding mid-stream")
+            sys.stdin = stream
+            sys.stdout = MagicMock()
+            sys.stderr = MagicMock()
+            # Should not raise — bad reconfigure is never fatal.
+            omnimem._force_utf8_streams()
+        finally:
+            sys.stdin, sys.stdout, sys.stderr = original
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What
Two small Windows-hygiene bugs surfaced when using v1.2.5 from a fresh shell.

### 1. \`note new --body -\` crashed on non-ASCII stdin
v1.2.5 reconfigured stdout/stderr to UTF-8 but missed stdin. On Windows the cp1252 + \`surrogateescape\` decoder turned heredoc bytes into surrogates (\`\udc8d\`), which \`Path.write_text(encoding=\"utf-8\")\` then refused with \"surrogates not allowed\".

**Fix:** extend \`_force_utf8_streams\` in \`omnimem.py\` to also reconfigure \`sys.stdin\`. New \`tests/test_stdin_utf8.py\` (3 cases) pins all three streams, plus no-reconfigure-method and reconfigure-failure escape paths.

### 2. Docs referenced an \`install\` subcommand that doesn't exist
Every README / QUICKSTART / docs page wrote \`omnimem hook install --agent claude\`. The CLI has no positional \`install\` — installation is the default behavior of the \`hook\` subcommand, with \`--uninstall\` and \`--status\` as flags. Users following the docs got argparse \`unrecognized arguments: install\`.

**Fix:** replace \`omnimem hook install\` with \`omnimem hook\` everywhere it referred to the actual command syntax — README (3 langs), QUICKSTART, docs/{hooks,codemap,benchmarks,faq}.md, omnimem.py argparse help for --gated-reindex, omni_hooks.py docstring, tests/test_hook_path_quoting.py docstring. \`omni_quickstart.py\` runtime messages updated to \"hook installation\" for natural wording. CHANGELOG.md / ROADMAP.md historical entries kept verbatim.

## Test plan
- [x] \`python -m unittest discover -s tests\` — 241 passed, 1 skipped, 0 failed.
- [x] Stdin smoke: \`echo "Tiếng Việt: ăn cơm" | omnimem note new ... --body -\` — note created cleanly, no UnicodeEncodeError.
- [x] CI matrix on PR will exercise this on Ubuntu/Windows/macOS x Py3.10/3.11/3.12.