### PR TITLE
fix(setup): install omnimem package via pip -e to enable -m omnimem invocations

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -9,6 +9,7 @@ call venv\Scripts\activate.bat
 
 echo [2/4] Installing dependencies (Kreuzberg, ChromaDB)...
 pip install -r requirements.txt >nul 2>&1
+pip install -e . >nul 2>&1
 
 echo [3/4] Bootstrapping the local embedding model...
 if "%OMNIMEM_SKIP_MODEL_BOOTSTRAP%"=="1" (

--- a/setup.ps1
+++ b/setup.ps1
@@ -8,6 +8,7 @@ python -m venv venv
 
 Write-Host "[2/4] Installing dependencies (Kreuzberg, ChromaDB)..."
 pip install -r requirements.txt | Out-Null
+pip install -e . | Out-Null
 
 Write-Host "[3/4] Bootstrapping the local embedding model..."
 if ($env:OMNIMEM_SKIP_MODEL_BOOTSTRAP -eq "1") {

--- a/setup.sh
+++ b/setup.sh
@@ -12,6 +12,7 @@ source venv/bin/activate
 # 2. Install Dependencies
 echo "[2/4] Installing dependencies (Kreuzberg, ChromaDB)..."
 pip install -r requirements.txt > /dev/null 2>&1
+pip install -e . > /dev/null 2>&1
 
 echo "[3/4] Bootstrapping the local embedding model..."
 if [ "${OMNIMEM_SKIP_MODEL_BOOTSTRAP:-0}" = "1" ]; then


### PR DESCRIPTION
## Summary
- `setup.sh` / `setup.bat` / `setup.ps1` only installed `requirements.txt`, never the `omnimem` package itself, so `python -m omnimem` (used by the stop hook installed via `omnimem hook install`) failed on every fresh install with `ModuleNotFoundError: No module named 'omnimem'`.
- Path-based `./omnimem` launcher kept working, which masked the bug — but anyone whose agent harness invokes the module form (Claude Code stop hooks, MCP server bootstraps that import the package, etc.) hit it.
- `pyproject.toml` already declares the package installable (`[project.scripts] omnimem = "omnimem:main"`); the fix is one line per setup script: run `pip install -e .` right after the deps install.

## Repro (pre-fix)
1. Clone the repo into a clean dir, run `./setup.sh` (or `setup.bat` / `setup.ps1`).
2. `./venv/bin/python3 -m omnimem note list --limit 1 --json` → `ModuleNotFoundError: No module named 'omnimem'`.
3. `pip install -e .` → command works.

## Test plan
- [x] `bash -n setup.sh` syntax check passes.
- [x] Local Windows venv: `pip install -e .` succeeds; `python -c "import omnimem"` works; `python -m omnimem note list --limit 1 --json` returns valid JSON.
- [ ] CI matrix (ubuntu/windows/macos × py 3.10/3.11/3.12) green.