### PR TITLE
fix(test): pass --no-hardlinks to local git clones in test_omni_update

### DIFF
--- a/tests/test_omni_update.py
+++ b/tests/test_omni_update.py
@@ -48,9 +48,9 @@ class TestOmniUpdate(unittest.TestCase):
         self._git(["git", "commit", "-m", "seed"], cwd=self.seed_repo)
         self._git(["git", "branch", "-M", "main"], cwd=self.seed_repo)
 
-        self._git(["git", "clone", "--bare", str(self.seed_repo), str(self.remote_repo)], cwd=self.temp_path)
-        self._git(["git", "clone", str(self.remote_repo), str(self.source_repo)], cwd=self.temp_path)
-        self._git(["git", "clone", str(self.remote_repo), str(self.client_repo)], cwd=self.temp_path)
+        self._git(["git", "clone", "--bare", "--no-hardlinks", str(self.seed_repo), str(self.remote_repo)], cwd=self.temp_path)
+        self._git(["git", "clone", "--no-hardlinks", str(self.remote_repo), str(self.source_repo)], cwd=self.temp_path)
+        self._git(["git", "clone", "--no-hardlinks", str(self.remote_repo), str(self.client_repo)], cwd=self.temp_path)
         self._git(["git", "config", "user.name", "Codex Test"], cwd=self.source_repo)
         self._git(["git", "config", "user.email", "codex@example.com"], cwd=self.source_repo)
 

--- a/tests/test_omni_update.py
+++ b/tests/test_omni_update.py
@@ -29,7 +29,7 @@ def run(cmd, cwd):
 
 class TestOmniUpdate(unittest.TestCase):
     def setUp(self):
-        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         self.temp_path = Path(self.temp_dir.name)
         self.seed_repo = self.temp_path / "seed"
         self.remote_repo = self.temp_path / "remote.git"


### PR DESCRIPTION
## Summary
- `tests/test_omni_update.py` makes three local-to-local `git clone` calls in `setUp` (seed → bare remote → source / client). git defaults to hardlinking objects on local clones, which on a recent macOS GHA runner image started racing — clone succeeds copying the pack, then immediate checkout fails reading the hardlinked loose object.
- Symptom: `error: unable to read sha1 file of omni_hooks.py (14d5de00...)` / `fatal: unable to checkout working tree` / `Clone succeeded, but checkout failed`. All three macOS python cells failed on commit 6629db1; a rerun unstuck 3.11 / 3.12 but 3.10 stayed red on the same SHA.
- Fix: pass `--no-hardlinks` so git copies objects instead of linking them. Trivial cost for a tiny fixture repo; sidesteps the APFS visibility race.

## Repro (pre-fix)
- Run #25298331330 (push to main after #18) failed all 3 macOS cells.
- Rerun → 2/3 pass, macos-3.10 still failed with identical error.

## Test plan
- [x] Local Windows: `python -m unittest tests.test_omni_update -v` → 3 tests pass.
- [ ] CI matrix (ubuntu/windows/macos × py 3.10/3.11/3.12) green.