### PR TITLE
docs: cover v1.2.7 hook/MCP auto-migration

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -53,6 +53,37 @@ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' | omnimem mcp 
 
 You should get a JSON-RPC response within 1-2 seconds.
 
+### Stop hook fails with `'omnimem' is a package and cannot be directly executed`
+
+Symptom — Claude Code shows:
+
+```
+Stop hook error: ... C:\...\python.exe: No module named omnimem.__main__;
+'omnimem' is a package and cannot be directly executed
+```
+
+Cause — your `~/.claude/settings.json` (or `~/.codex/config.toml`, or
+an MCP `mcp.json` / `settings.json`) was installed by OmniMem v1.2.6 or
+earlier, or hand-copied from older docs. The entries call
+`<python> -m omnimem ...`, which runpy refuses whenever any `sys.path`
+entry resolves `omnimem` to a package or namespace package.
+
+Fix — upgrade to v1.2.7+ and run any of:
+
+```bash
+pip install --upgrade omnimem        # or: cd <checkout> && git pull && pip install -e .
+omnimem hook --status                # auto-migrates Claude / Codex hook entries
+omnimem init --status                # auto-migrates Claude / Codex / Gemini / Cursor MCP entries
+```
+
+Both `hook` and `init` rewrite stale `<python> -m omnimem ...` commands to
+the `omnimem` console-script form on every invocation (idempotent). After
+running once, restart your agent CLI so it re-reads the config.
+
+If you still see the error after migration, check the hook entry by hand
+in `~/.claude/settings.json` — the `command` field should start with the
+path to `omnimem.exe` (Windows) or `omnimem` (POSIX), with no `-m omnimem`.
+
 ### Codex CLI hooks don't fire
 
 Codex CLI's hook key surface has shifted across versions. The OmniMem installer ships the **most-common shape** but your version may use different keys. Open `~/.codex/config.toml` and edit between the marker comments:

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -10,7 +10,7 @@
 | `Stop` | Lists today's notes, prompting the agent to reflect on what was just completed. |
 | `PostToolUse` (Edit, Write, MultiEdit) | Triggers `omnimem note reindex` so any agent-edited note files re-sync to the ChromaDB notes collection. |
 
-Each entry is tagged with `"tag": "omnimem-v1"` inside the hook so reinstalling and uninstalling can target only the OmniMem entries without touching user-defined hooks.
+Each entry is tagged with `"tag": "omnimem-v1"` inside the hook so reinstalling and uninstalling can target only the OmniMem entries without touching user-defined hooks. (One exception: the auto-migrator, see below, intentionally rewrites stale `<python> -m omnimem ...` commands regardless of tag, including hand-installed entries from earlier docs.)
 
 ## Install
 
@@ -55,6 +55,18 @@ The installer is idempotent:
 - Pre-existing OmniMem entries are removed before new ones are written.
 - Reinstalling produces an identical file.
 - User-defined hooks alongside the OmniMem ones are preserved across install / reinstall / uninstall.
+
+## Auto-migration (v1.2.7+)
+
+Every `omnimem hook ...` and `omnimem init ...` invocation (except `omnimem hook --gated-reindex`, which fires on every PostToolUse) runs an idempotent sweep that rewrites stale `<python> -m omnimem ...` entries to the modern `omnimem` console-script form. Coverage:
+
+- Claude `~/.claude/settings.json` and `<project>/.claude/settings.json`
+- Codex `~/.codex/config.toml` (hook block + `[mcp_servers.omnimem]`)
+- Claude / Cursor / Gemini `mcp.json` / `settings.json`
+
+Detection is by **command shape**, not by the `omnimem-v1` tag, so entries you copy-pasted from pre-v1.2.7 docs (or that pre-date the tag) are also fixed. Migration preserves your existing structure — matchers, sibling entries, and ordering are kept intact and we do **not** auto-tag entries we did not previously own. Already-modern configs are a no-op.
+
+If a migration ran, the JSON output of `omnimem hook --status --json` includes a top-level `"migrated": [...]` field listing the rewrites. See [`CHANGELOG.md`](../CHANGELOG.md) for the v1.2.7 background.
 
 ## Customizing the recipe
 


### PR DESCRIPTION
## Summary

Doc-only follow-up to PR #20 / v1.2.7 release.

- **TROUBLESHOOTING.md** — new section for the `'omnimem' is a package and cannot be directly executed` Stop hook error, with the `omnimem hook --status` / `omnimem init --status` recovery commands users on v1.2.6 will need.
- **docs/hooks.md** — clarify the `omnimem-v1` tag still governs install / uninstall scoping, but the v1.2.7 auto-migrator intentionally rewrites stale `<python> -m omnimem ...` entries regardless of tag. New \"Auto-migration (v1.2.7+)\" subsection documents what it covers, how detection works (by command shape), and the `--status --json` `migrated` surface.

No code changes.

## Test plan

- [x] Read-through: docs render correctly, links resolve
- [ ] CI matrix (no functional change, just to confirm nothing else regressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)