### PR TITLE
docs: bump README headlines to v1.2.7 + lock with test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OmniMem v1.2.6 - The CLI Second Brain 🧠
+# OmniMem v1.2.7 - The CLI Second Brain 🧠
 
 [Tiếng Việt](README_vi.md) | [Русский](README_ru.md) | [English](README.md)
 
@@ -160,7 +160,7 @@ What `omnimem hook` does (Claude Code + Codex CLI only):
 - `Stop` → lists today's notes so the agent reflects on what was just completed.
 - `PostToolUse` (Edit / Write / MultiEdit) → triggers `omnimem note reindex` so any edited markdown re-syncs into ChromaDB.
 
-Each entry is tagged `omnimem-v1` so the installer can coexist with any hand-authored hooks you already have. Path quoting on Windows uses POSIX forward slashes, which `bash -c` accepts natively (a fix added in v1.2.4).
+Each entry is tagged `omnimem-v1` so the installer can coexist with any hand-authored hooks you already have. Hook commands launch the `omnimem` console script (no `python -m omnimem`, fix in v1.2.7) and quote Windows paths with POSIX forward slashes for `bash -c` (fix in v1.2.4). v1.2.7+ also auto-rewrites stale `<python> -m omnimem ...` entries from earlier installs on the next `omnimem hook` / `omnimem init` invocation.
 
 ### What the agent sees after install
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -1,4 +1,4 @@
-# OmniMem v1.2.6 - CLI «Второй Мозг» 🧠
+# OmniMem v1.2.7 - CLI «Второй Мозг» 🧠
 
 [Tiếng Việt](README_vi.md) | [Русский](README_ru.md) | [English](README.md)
 

--- a/README_vi.md
+++ b/README_vi.md
@@ -1,4 +1,4 @@
-# OmniMem v1.2.6 - Bộ Não CLI Thứ Hai 🧠
+# OmniMem v1.2.7 - Bộ Não CLI Thứ Hai 🧠
 
 [Tiếng Việt](README_vi.md) | [Русский](README_ru.md) | [English](README.md)
 

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -10,6 +10,18 @@ class TestReleaseMetadata(unittest.TestCase):
         changelog = (ROOT_DIR / "CHANGELOG.md").read_text(encoding="utf-8")
         self.assertIn(f"## v{version}", changelog)
 
+    def test_readme_headlines_match_current_version(self):
+        version = (ROOT_DIR / "VERSION").read_text(encoding="utf-8").strip()
+        for name in ("README.md", "README_vi.md", "README_ru.md"):
+            path = ROOT_DIR / name
+            self.assertTrue(path.exists(), f"{name} missing")
+            first_line = path.read_text(encoding="utf-8").splitlines()[0]
+            self.assertIn(
+                f"v{version}",
+                first_line,
+                f"{name} headline does not advertise current VERSION ({version}): {first_line!r}",
+            )
+
     def test_release_checklist_exists(self):
         checklist = ROOT_DIR / "docs" / "release-checklist.md"
         self.assertTrue(checklist.exists())


### PR DESCRIPTION
## Summary

PR #20 / v1.2.7 bumped `VERSION` + `CHANGELOG.md` but missed the headline in the three READMEs (still advertised v1.2.6). Reported by maintainer immediately after the release.

- `README.md` / `README_vi.md` / `README_ru.md` — first-line headline bumped to v1.2.7.
- `README.md` line 163 — extended the hooks paragraph to credit the v1.2.7 console-script fix alongside the existing v1.2.4 path-quoting fix, and document the v1.2.7+ auto-migration behaviour.
- `tests/test_release_metadata.py` — new `test_readme_headlines_match_current_version` asserts each README's first line contains `v<VERSION>`. Same guardrail style as the existing `test_changelog_contains_current_version`. Future releases that forget to bump a README will fail the suite.

## Test plan

- [x] `python -m unittest tests.test_release_metadata` — 14 pass (was 13)
- [ ] CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)